### PR TITLE
Guardian SchnoorProof no longer needs crypto_base_hash, remove and propagate through the code.

### DIFF
--- a/src/main/java/com/sunya/electionguard/ElectionPolynomial.java
+++ b/src/main/java/com/sunya/electionguard/ElectionPolynomial.java
@@ -69,17 +69,16 @@ public class ElectionPolynomial {
    * Generates a polynomial when the coefficients are already chosen
    *
    * @param coefficients:           the k coefficients of the polynomial
-   * @param crypto_base_hash:       needed for the Schnorr proof.
    * @return Polynomial used to share election keys
    */
-  static ElectionPolynomial generate_polynomial(List<Group.ElementModQ> coefficients, ElementModQ crypto_base_hash) {
+  static ElectionPolynomial generate_polynomial(List<Group.ElementModQ> coefficients) {
     ArrayList<Group.ElementModP> commitments = new ArrayList<>();
     ArrayList<SchnorrProof> proofs = new ArrayList<>();
 
     for (Group.ElementModQ coefficient : coefficients) {
       Group.ElementModP commitment = g_pow_p(coefficient);
       // TODO Alternate schnorr proof method that doesn't need KeyPair
-      SchnorrProof proof = SchnorrProof.make_schnorr_proof(new ElGamal.KeyPair(coefficient, commitment), rand_q(), crypto_base_hash);
+      SchnorrProof proof = SchnorrProof.make_schnorr_proof(new ElGamal.KeyPair(coefficient, commitment), rand_q());
       commitments.add(commitment);
       proofs.add(proof);
     }
@@ -92,10 +91,9 @@ public class ElectionPolynomial {
    *
    * @param number_of_coefficients: Number of coefficients of polynomial: the quorum, k.
    * @param nonce:                  an optional nonce parameter that may be provided (only for testing)
-   * @param crypto_base_hash:       needed for the Schnorr proof.
    * @return Polynomial used to share election keys
    */
-  static ElectionPolynomial generate_polynomial(int number_of_coefficients, @Nullable Group.ElementModQ nonce, ElementModQ crypto_base_hash) {
+  static ElectionPolynomial generate_polynomial(int number_of_coefficients, @Nullable Group.ElementModQ nonce) {
     ArrayList<Group.ElementModQ> coefficients = new ArrayList<>();
     ArrayList<Group.ElementModP> commitments = new ArrayList<>();
     ArrayList<SchnorrProof> proofs = new ArrayList<>();
@@ -107,7 +105,7 @@ public class ElectionPolynomial {
       Group.ElementModQ coefficient = (nonce == null) ? rand_q() : add_q(nonce, coeff_value);
       Group.ElementModP commitment = g_pow_p(coefficient);
       // TODO Alternate schnorr proof method that doesn't need KeyPair
-      SchnorrProof proof = SchnorrProof.make_schnorr_proof(new ElGamal.KeyPair(coefficient, commitment), rand_q(), crypto_base_hash);
+      SchnorrProof proof = SchnorrProof.make_schnorr_proof(new ElGamal.KeyPair(coefficient, commitment), rand_q());
 
       coefficients.add(coefficient);
       commitments.add(commitment);

--- a/src/main/java/com/sunya/electionguard/KeyCeremony.java
+++ b/src/main/java/com/sunya/electionguard/KeyCeremony.java
@@ -144,11 +144,11 @@ public class KeyCeremony {
     }
 
     // This is what the Guardian needs.
-    ElectionKeyPair generate_election_key_pair(ElementModQ crypto_base_hash) {
-      ElectionPolynomial polynomial = ElectionPolynomial.generate_polynomial(coefficients(), crypto_base_hash);
+    ElectionKeyPair generate_election_key_pair() {
+      ElectionPolynomial polynomial = ElectionPolynomial.generate_polynomial(coefficients());
       ElGamal.KeyPair key_pair = new ElGamal.KeyPair(
               polynomial.coefficients.get(0), polynomial.coefficient_commitments.get(0));
-      SchnorrProof proof = SchnorrProof.make_schnorr_proof(key_pair, rand_q(), crypto_base_hash);
+      SchnorrProof proof = SchnorrProof.make_schnorr_proof(key_pair, rand_q());
       return ElectionKeyPair.create(key_pair, proof, polynomial);
     }
   }
@@ -193,14 +193,14 @@ public class KeyCeremony {
    * @param quorum: Quorum of guardians needed to decrypt
    * @param nonce: Optional nonce for determinism, use null when generating in production.
    */
-  static ElectionKeyPair generate_election_key_pair(int quorum, @Nullable ElementModQ nonce, ElementModQ crypto_base_hash) {
-    ElectionPolynomial polynomial = ElectionPolynomial.generate_polynomial(quorum, nonce, crypto_base_hash);
+  static ElectionKeyPair generate_election_key_pair(int quorum, @Nullable ElementModQ nonce) {
+    ElectionPolynomial polynomial = ElectionPolynomial.generate_polynomial(quorum, nonce);
     // the 0th coefficient is the secret s for the ith Guardian
     // the 0th commitment is the public key = g^s mod p
     // The key_pair is Ki = election keypair for ith Guardian
     ElGamal.KeyPair key_pair = new ElGamal.KeyPair(
             polynomial.coefficients.get(0), polynomial.coefficient_commitments.get(0));
-    SchnorrProof proof = SchnorrProof.make_schnorr_proof(key_pair, rand_q(), crypto_base_hash);
+    SchnorrProof proof = SchnorrProof.make_schnorr_proof(key_pair, rand_q());
     return ElectionKeyPair.create(key_pair, proof, polynomial);
   }
 

--- a/src/main/java/com/sunya/electionguard/SchnorrProof.java
+++ b/src/main/java/com/sunya/electionguard/SchnorrProof.java
@@ -35,7 +35,7 @@ public class SchnorrProof extends Proof {
    * This is specification 2A and 2.B.
    * @return true if the transcript is valid, false if anything is wrong
    */
-  boolean is_valid(ElementModQ crypto_base_hash) {
+  boolean is_valid() {
     ElementModP k = this.public_key;
     ElementModP h = this.commitment;
     ElementModQ u = this.response;
@@ -43,7 +43,7 @@ public class SchnorrProof extends Proof {
     boolean in_bounds_h = h.is_in_bounds();
     boolean in_bounds_u = u.is_in_bounds();
 
-    // LOOK changed validation spec 2.A. see issue #278
+    // Changed validation spec 2.A. see issue #278
     boolean valid_2A = this.challenge.equals(Hash.hash_elems(k, h));
     boolean valid_2B = g_pow_p(u).equals(Group.mult_p(h, Group.pow_p(k, this.challenge)));
 
@@ -86,10 +86,10 @@ public class SchnorrProof extends Proof {
    * @param keypair An ElGamal keypair.
    * @param nonce   A random element in [0,Q).
    */
-  static SchnorrProof make_schnorr_proof(ElGamal.KeyPair keypair, ElementModQ nonce, ElementModQ crypto_base_hash) {
+  static SchnorrProof make_schnorr_proof(ElGamal.KeyPair keypair, ElementModQ nonce) {
     ElementModP k = keypair.public_key;
     ElementModP h = g_pow_p(nonce);
-    // LOOK changed validation spec 2.A. see issue #278
+    // Changed validation spec 2.A. see issue #278
     ElementModQ c = Hash.hash_elems(k, h);
     ElementModQ u = a_plus_bc_q(nonce, keypair.secret_key, c);
     return new SchnorrProof(k, h, c, u);

--- a/src/main/java/com/sunya/electionguard/proto/KeyCeremonyFromProto.java
+++ b/src/main/java/com/sunya/electionguard/proto/KeyCeremonyFromProto.java
@@ -33,19 +33,17 @@ public class KeyCeremonyFromProto {
   private static ImmutableList<Guardian> convertGuardians(KeyCeremonyProto.Guardians proto) {
     int quorum = proto.getQuorum();
     int nguardians = proto.getGuardiansCount();
-    Group.ElementModQ cryptoBaseHash = CommonConvert.convertElementModQ(proto.getCryptoBaseHash());
     ImmutableList.Builder<Guardian> builder = ImmutableList.builder();
     for (KeyCeremonyProto.Guardian guardianProto : proto.getGuardiansList()) {
-      builder.add(convertGuardian(guardianProto, nguardians, quorum, cryptoBaseHash));
+      builder.add(convertGuardian(guardianProto, nguardians, quorum));
     }
     return builder.build();
   }
 
-  private static Guardian convertGuardian(KeyCeremonyProto.Guardian proto, int nguardians, int quorum,
-                                          Group.ElementModQ cryptoBaseHash) {
+  private static Guardian convertGuardian(KeyCeremonyProto.Guardian proto, int nguardians, int quorum) {
 
     KeyCeremony.CoefficientSet coefficients = convertCoefficients(proto.getCoefficients());
-    GuardianBuilder builder = new GuardianBuilder(coefficients, nguardians, quorum, cryptoBaseHash,
+    GuardianBuilder builder = new GuardianBuilder(coefficients, nguardians, quorum,
             convertAuxiliaryKeyPair(proto.getAuxiliaryKeys()),
             convertElectionKeys(proto.getElectionKeys()));
 

--- a/src/main/java/com/sunya/electionguard/proto/KeyCeremonyToProto.java
+++ b/src/main/java/com/sunya/electionguard/proto/KeyCeremonyToProto.java
@@ -18,10 +18,9 @@ import static com.sunya.electionguard.proto.CommonConvert.convertSchnorrProof;
 
 public class KeyCeremonyToProto {
 
-  public static KeyCeremonyProto.Guardians convertGuardians(List<Guardian> guardians, int quorum, Group.ElementModQ crypto_base_hash) {
+  public static KeyCeremonyProto.Guardians convertGuardians(List<Guardian> guardians, int quorum) {
     KeyCeremonyProto.Guardians.Builder builder = KeyCeremonyProto.Guardians.newBuilder();
     builder.setQuorum(quorum);
-    builder.setCryptoBaseHash(convertElementModQ(crypto_base_hash));
     guardians.forEach(g -> builder.addGuardians(convertGuardian(g)));
     return builder.build();
   }

--- a/src/main/java/com/sunya/electionguard/workflow/PerformKeyCeremony.java
+++ b/src/main/java/com/sunya/electionguard/workflow/PerformKeyCeremony.java
@@ -181,7 +181,7 @@ public class PerformKeyCeremony {
 
     this.guardianBuilders = new ArrayList<>();
     for (KeyCeremony.CoefficientSet coeffSet : coefficientsProvider.guardianCoefficients()) {
-      this.guardianBuilders.add(GuardianBuilder.createRandom(coeffSet, numberOfGuardians, quorum, this.crypto_base_hash));
+      this.guardianBuilders.add(GuardianBuilder.createRandom(coeffSet, numberOfGuardians, quorum));
     }
 
     System.out.printf("%nKey Ceremony%n");
@@ -289,8 +289,7 @@ public class PerformKeyCeremony {
 
     // the quardians - private info
     List<Guardian> guardians = guardianBuilders.stream().map(gb -> gb.build()).collect(Collectors.toList());
-    KeyCeremonyProto.Guardians guardianProto = KeyCeremonyToProto.convertGuardians(guardians,
-            this.quorum, this.crypto_base_hash);
+    KeyCeremonyProto.Guardians guardianProto = KeyCeremonyToProto.convertGuardians(guardians, this.quorum);
 
     publisher.writeGuardiansProto(guardianProto);
   }

--- a/src/main/proto/com/sunya/electionguard/proto/key_ceremony.proto
+++ b/src/main/proto/com/sunya/electionguard/proto/key_ceremony.proto
@@ -7,7 +7,6 @@ option java_outer_classname = "KeyCeremonyProto";
 
 message Guardians {
   uint32 quorum = 2;
-  ElementModQ crypto_base_hash = 3;
   repeated Guardian guardians = 1;
 }
 

--- a/src/test/java/com/sunya/electionguard/TestDecryptProblem.java
+++ b/src/test/java/com/sunya/electionguard/TestDecryptProblem.java
@@ -131,10 +131,9 @@ public class TestDecryptProblem {
    */
   void step_1_key_ceremony() {
     System.out.printf("%n1. Key Ceremony%n");
-    Group.ElementModQ crypto_base_hash = Election.make_crypto_base_hash(NUMBER_OF_GUARDIANS, QUORUM, election);
     // Setup Guardians
     for (int i = 1; i <= NUMBER_OF_GUARDIANS; i++) {
-      this.guardianBuilders.add(GuardianBuilder.createForTesting("guardian_" + i, i, NUMBER_OF_GUARDIANS, QUORUM, crypto_base_hash, null));
+      this.guardianBuilders.add(GuardianBuilder.createForTesting("guardian_" + i, i, NUMBER_OF_GUARDIANS, QUORUM,  null));
     }
 
     // Setup Mediator
@@ -187,6 +186,7 @@ public class TestDecryptProblem {
     this.context = tuple.context;
     this.constants = new ElectionConstants();
 
+    Group.ElementModQ crypto_base_hash = Election.make_crypto_base_hash(NUMBER_OF_GUARDIANS, QUORUM, election);
     assertThat(this.context.crypto_base_hash).isEqualTo(crypto_base_hash);
   }
 

--- a/src/test/java/com/sunya/electionguard/TestDecryptionMediator.java
+++ b/src/test/java/com/sunya/electionguard/TestDecryptionMediator.java
@@ -50,11 +50,10 @@ public class TestDecryptionMediator extends TestProperties {
     this.key_ceremony = new KeyCeremonyMediator(CEREMONY_DETAILS);
 
     // Setup Guardians
-    ElementModQ crypto_hash = rand_q();
     List<GuardianBuilder> guardianBuilders = new ArrayList<>();
     for (int i = 0; i < NUMBER_OF_GUARDIANS; i++) {
       int sequence = i + 2;
-      guardianBuilders.add(GuardianBuilder.createForTesting("guardian_" + sequence, sequence, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash, null));
+      guardianBuilders.add(GuardianBuilder.createForTesting("guardian_" + sequence, sequence, NUMBER_OF_GUARDIANS, QUORUM, null));
     }
     guardianBuilders.forEach(gb -> this.key_ceremony.announce(gb));
     this.key_ceremony.orchestrate(identity_auxiliary_encrypt);

--- a/src/test/java/com/sunya/electionguard/TestDecryptionMediatorProblem.java
+++ b/src/test/java/com/sunya/electionguard/TestDecryptionMediatorProblem.java
@@ -42,11 +42,10 @@ public class TestDecryptionMediatorProblem extends TestProperties {
     this.key_ceremony = new KeyCeremonyMediator(CEREMONY_DETAILS);
 
     // Setup Guardians
-    ElementModQ crypto_hash = rand_q();
     List<GuardianBuilder> guardianBuilders = new ArrayList<>();
     for (int i = 0; i < NUMBER_OF_GUARDIANS; i++) {
       int sequence = i + 2;
-      guardianBuilders.add(GuardianBuilder.createForTesting("guardian_" + sequence, sequence, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null));
+      guardianBuilders.add(GuardianBuilder.createForTesting("guardian_" + sequence, sequence, NUMBER_OF_GUARDIANS, QUORUM,null));
     }
     guardianBuilders.forEach(gb -> this.key_ceremony.announce(gb));
     this.key_ceremony.orchestrate(identity_auxiliary_encrypt);

--- a/src/test/java/com/sunya/electionguard/TestElectionPolynomial.java
+++ b/src/test/java/com/sunya/electionguard/TestElectionPolynomial.java
@@ -14,11 +14,10 @@ import static com.sunya.electionguard.Group.*;
 public class TestElectionPolynomial {
   private static final int TEST_POLYNOMIAL_DEGREE = 3;
   private static final BigInteger TEST_EXPONENT_MODIFIER = BigInteger.ONE;
-  private static final ElementModQ crypto_hash = Group.rand_q();
 
   @Example
   public void test_contest_description_valid_input_succeeds() {
-    ElectionPolynomial polynomial = generate_polynomial(TEST_POLYNOMIAL_DEGREE, null, crypto_hash);
+    ElectionPolynomial polynomial = generate_polynomial(TEST_POLYNOMIAL_DEGREE, null);
     assertThat(polynomial).isNotNull();
   }
 
@@ -35,7 +34,7 @@ public class TestElectionPolynomial {
 
   @Example
   public void test_verify_polynomial_coordinate() {
-    ElectionPolynomial polynomial = generate_polynomial(TEST_POLYNOMIAL_DEGREE, null, crypto_hash);
+    ElectionPolynomial polynomial = generate_polynomial(TEST_POLYNOMIAL_DEGREE, null);
 
     Group.ElementModQ value = compute_polynomial_coordinate(TEST_EXPONENT_MODIFIER, polynomial);
     assertThat(verify_polynomial_coordinate(

--- a/src/test/java/com/sunya/electionguard/TestEndToEndElectionIntegration.java
+++ b/src/test/java/com/sunya/electionguard/TestEndToEndElectionIntegration.java
@@ -128,10 +128,9 @@ public class TestEndToEndElectionIntegration {
    */
   void step_1_key_ceremony() {
     System.out.printf("%n1. Key Ceremony%n");
-    Group.ElementModQ crypto_base_hash = Election.make_crypto_base_hash(NUMBER_OF_GUARDIANS, QUORUM, election);
     // Setup Guardians
     for (int i = 1; i <= NUMBER_OF_GUARDIANS; i++) {
-      this.guardianBuilders.add(GuardianBuilder.createForTesting("guardian_" + i, i, NUMBER_OF_GUARDIANS, QUORUM, crypto_base_hash, null));
+      this.guardianBuilders.add(GuardianBuilder.createForTesting("guardian_" + i, i, NUMBER_OF_GUARDIANS, QUORUM, null));
     }
 
     // Setup Mediator
@@ -183,7 +182,7 @@ public class TestEndToEndElectionIntegration {
     this.election = tuple.metadata.election;
     this.context = tuple.context;
     this.constants = new ElectionConstants();
-
+    Group.ElementModQ crypto_base_hash = Election.make_crypto_base_hash(NUMBER_OF_GUARDIANS, QUORUM, election);
     assertThat(this.context.crypto_base_hash).isEqualTo(crypto_base_hash);
   }
 

--- a/src/test/java/com/sunya/electionguard/TestGuardianBuilder.java
+++ b/src/test/java/com/sunya/electionguard/TestGuardianBuilder.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
-import static com.sunya.electionguard.Group.rand_q;
 
 public class TestGuardianBuilder {
   private static final String SENDER_GUARDIAN_ID = "Test GuardianBuilder 1";
@@ -17,14 +16,13 @@ public class TestGuardianBuilder {
   private static final int ALTERNATE_VERIFIER_SEQUENCE_ORDER = 3;
   private static final int NUMBER_OF_GUARDIANS = 2;
   private static final int QUORUM = 2;
-  private static final Group.ElementModQ crypto_hash = rand_q();
 
   static Auxiliary.Decryptor identity_auxiliary_decryptor = (m, k) -> Optional.of(new String(m.getBytes()));
   static Auxiliary.Encryptor identity_auxiliary_encryptor = (m, k) -> Optional.of(new Auxiliary.ByteString(m.getBytes()));
 
   @Example
   public void test_share_public_keys() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM,null);
 
     KeyCeremony.PublicKeySet public_keys = guardian.share_public_keys();
 
@@ -33,13 +31,13 @@ public class TestGuardianBuilder {
     assertThat(public_keys.election_public_key()).isNotNull();
     assertThat(public_keys.owner_id()).isEqualTo(SENDER_GUARDIAN_ID);
     assertThat(public_keys.sequence_order()).isEqualTo(SENDER_SEQUENCE_ORDER);
-    assertThat(public_keys.election_public_key_proof().is_valid(guardian.crypto_base_hash())).isTrue();
+    assertThat(public_keys.election_public_key_proof().is_valid()).isTrue();
   }
 
   @Example
   public void test_save_guardian_public_keys() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
-    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
+    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
 
     KeyCeremony.PublicKeySet public_keys = other_guardian.share_public_keys();
     guardian.save_guardian_public_keys(public_keys);
@@ -50,8 +48,8 @@ public class TestGuardianBuilder {
 
   @Example
   public void test_all_public_keys_received() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
-    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
+    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
 
     KeyCeremony.PublicKeySet public_keys = other_guardian.share_public_keys();
 
@@ -63,7 +61,7 @@ public class TestGuardianBuilder {
 
   @Example
   public void test_share_auxiliary_public_key() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
 
     Auxiliary.PublicKey public_key = guardian.share_auxiliary_public_key();
 
@@ -75,8 +73,8 @@ public class TestGuardianBuilder {
 
   @Example
   public void test_save_auxiliary_public_key() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
-    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
+    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
     Auxiliary.PublicKey public_key = other_guardian.share_auxiliary_public_key();
 
     guardian.save_auxiliary_public_key(public_key);
@@ -86,8 +84,8 @@ public class TestGuardianBuilder {
 
   @Example
   public void test_all_auxiliary_public_keys_received() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
-    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
+    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
     Auxiliary.PublicKey public_key = other_guardian.share_auxiliary_public_key();
 
     assertThat(guardian.all_auxiliary_public_keys_received()).isFalse();
@@ -112,19 +110,19 @@ public class TestGuardianBuilder {
 
   @Example
   public void test_share_election_public_key() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
     KeyCeremony.ElectionPublicKey public_key = guardian.share_election_public_key();
 
     assertThat(public_key).isNotNull();
     assertThat(public_key.key()).isNotNull();
     assertThat(public_key.owner_id()).isEqualTo(SENDER_GUARDIAN_ID);
-    assertThat(public_key.proof().is_valid(guardian.crypto_base_hash())).isTrue();
+    assertThat(public_key.proof().is_valid()).isTrue();
   }
 
   @Example
   public void test_save_election_public_key() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
-    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
+    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
     KeyCeremony.ElectionPublicKey public_key = other_guardian.share_election_public_key();
 
     guardian.save_election_public_key(public_key);
@@ -134,8 +132,8 @@ public class TestGuardianBuilder {
 
   @Example
   public void test_all_election_public_keys_received() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
-    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
+    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
     KeyCeremony.ElectionPublicKey public_key = other_guardian.share_election_public_key();
 
     assertThat(guardian.all_election_public_keys_received()).isFalse();
@@ -146,8 +144,8 @@ public class TestGuardianBuilder {
 
   @Example
   public void test_generate_election_partial_key_backups() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
-    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
+    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
     Optional<KeyCeremony.ElectionPartialKeyBackup> empty_key_backup = other_guardian.share_election_partial_key_backup(RECIPIENT_GUARDIAN_ID);
 
     assertThat(empty_key_backup).isEmpty();
@@ -164,14 +162,14 @@ public class TestGuardianBuilder {
     assertThat(key_backup.coefficient_commitments().size()).isEqualTo(QUORUM);
     assertThat(key_backup.coefficient_proofs().size()).isEqualTo(QUORUM);
     for (SchnorrProof proof : key_backup.coefficient_proofs()) {
-      assertThat(proof.is_valid(guardian.crypto_base_hash())).isTrue();
+      assertThat(proof.is_valid()).isTrue();
     }
   }
 
   @Example
   public void test_share_election_partial_key_backup() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
-    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
+    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
 
     guardian.save_auxiliary_public_key(other_guardian.share_auxiliary_public_key());
     guardian.generate_election_partial_key_backups(identity_auxiliary_encryptor);
@@ -186,14 +184,14 @@ public class TestGuardianBuilder {
     assertThat(key_backup.coefficient_commitments().size()).isEqualTo(QUORUM);
     assertThat(key_backup.coefficient_proofs().size()).isEqualTo(QUORUM);
     for (SchnorrProof proof : key_backup.coefficient_proofs()) {
-      assertThat(proof.is_valid(guardian.crypto_base_hash())).isTrue();
+      assertThat(proof.is_valid()).isTrue();
     }
   }
 
   @Example
   public void test_save_election_partial_key_backup() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
-    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
+    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
 
     guardian.save_auxiliary_public_key(other_guardian.share_auxiliary_public_key());
     guardian.generate_election_partial_key_backups(identity_auxiliary_encryptor);
@@ -208,8 +206,8 @@ public class TestGuardianBuilder {
 
   @Example
   public void test_all_election_partial_key_backups_received() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
-    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
+    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
 
     guardian.save_auxiliary_public_key(other_guardian.share_auxiliary_public_key());
     guardian.generate_election_partial_key_backups(identity_auxiliary_encryptor);
@@ -225,8 +223,8 @@ public class TestGuardianBuilder {
 
   @Example
   public void test_verify_election_partial_key_backup() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
-    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
+    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
 
     guardian.save_auxiliary_public_key(other_guardian.share_auxiliary_public_key());
     guardian.generate_election_partial_key_backups(identity_auxiliary_encryptor);
@@ -250,9 +248,9 @@ public class TestGuardianBuilder {
 
   @Example
   public void test_verify_election_partial_key_challenge() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
-    GuardianBuilder recipient_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
-    GuardianBuilder alternate_guardian = GuardianBuilder.createForTesting(ALTERNATE_VERIFIER_GUARDIAN_ID, ALTERNATE_VERIFIER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
+    GuardianBuilder recipient_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
+    GuardianBuilder alternate_guardian = GuardianBuilder.createForTesting(ALTERNATE_VERIFIER_GUARDIAN_ID, ALTERNATE_VERIFIER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
 
     guardian.save_auxiliary_public_key(recipient_guardian.share_auxiliary_public_key());
     guardian.generate_election_partial_key_backups(identity_auxiliary_encryptor);
@@ -271,8 +269,8 @@ public class TestGuardianBuilder {
 
   @Example
   public void test_publish_election_backup_challenge() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
-    GuardianBuilder recipient_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
+    GuardianBuilder recipient_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
 
     guardian.save_auxiliary_public_key(recipient_guardian.share_auxiliary_public_key());
     guardian.generate_election_partial_key_backups(identity_auxiliary_encryptor);
@@ -287,14 +285,14 @@ public class TestGuardianBuilder {
     assertThat(challenge.coefficient_commitments().size()).isEqualTo(QUORUM);
     assertThat(challenge.coefficient_proofs().size()).isEqualTo(QUORUM);
     for (SchnorrProof proof : challenge.coefficient_proofs()) {
-      assertThat(proof.is_valid(guardian.crypto_base_hash())).isTrue();
+      assertThat(proof.is_valid()).isTrue();
     }
   }
 
   @Example
   public void test_save_election_partial_key_verification() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
-    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
+    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
 
     guardian.save_auxiliary_public_key(other_guardian.share_auxiliary_public_key());
     guardian.generate_election_partial_key_backups(identity_auxiliary_encryptor);
@@ -312,8 +310,8 @@ public class TestGuardianBuilder {
 
   @Example
   public void test_all_election_partial_key_backups_verified() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
-    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
+    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
 
     guardian.save_auxiliary_public_key(other_guardian.share_auxiliary_public_key());
     guardian.generate_election_partial_key_backups(identity_auxiliary_encryptor);
@@ -331,8 +329,8 @@ public class TestGuardianBuilder {
 
   @Example
   public void test_publish_joint_key() {
-    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
-    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
+    GuardianBuilder guardian = GuardianBuilder.createForTesting(SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
+    GuardianBuilder other_guardian = GuardianBuilder.createForTesting(RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, NUMBER_OF_GUARDIANS, QUORUM, null);
 
     guardian.save_auxiliary_public_key(other_guardian.share_auxiliary_public_key());
     guardian.generate_election_partial_key_backups(identity_auxiliary_encryptor);

--- a/src/test/java/com/sunya/electionguard/TestKeyCeremony.java
+++ b/src/test/java/com/sunya/electionguard/TestKeyCeremony.java
@@ -19,8 +19,6 @@ public class TestKeyCeremony {
   private static final int NUMBER_OF_GUARDIANS = 5;
   private static final int QUORUM = 3;
 
-  private static final Group.ElementModQ crypto_hash = Group.rand_q();
-
   static Auxiliary.Decryptor identity_auxiliary_decrypt = (m, k) -> Optional.of(new String(m.getBytes()));
   static Auxiliary.Encryptor identity_auxiliary_encrypt = (m, k) -> Optional.of(new Auxiliary.ByteString(m.getBytes()));
 
@@ -35,21 +33,21 @@ public class TestKeyCeremony {
 
   @Example
   public void test_generate_election_key_pair() {
-    ElectionKeyPair election_key_pair = generate_election_key_pair(NUMBER_OF_GUARDIANS, null, crypto_hash);
+    ElectionKeyPair election_key_pair = generate_election_key_pair(NUMBER_OF_GUARDIANS, null);
 
     assertThat(election_key_pair).isNotNull();
     assertThat(election_key_pair.key_pair().public_key).isNotNull();
     assertThat(election_key_pair.key_pair().secret_key).isNotNull();
     assertThat(election_key_pair.polynomial()).isNotNull();
-    assertThat(election_key_pair.proof().is_valid(crypto_hash)).isTrue();
+    assertThat(election_key_pair.proof().is_valid()).isTrue();
     for (SchnorrProof proof : election_key_pair.polynomial().coefficient_proofs) {
-      assertThat(proof.is_valid(crypto_hash)).isTrue();
+      assertThat(proof.is_valid()).isTrue();
     }
   }
 
   @Example
   public void test_generate_election_partial_key_backup() {
-    ElectionKeyPair election_key_pair = generate_election_key_pair(QUORUM, null, crypto_hash);
+    ElectionKeyPair election_key_pair = generate_election_key_pair(QUORUM, null);
     Auxiliary.KeyPair auxiliary_key_pair = generate_rsa_auxiliary_key_pair();
     Auxiliary.PublicKey auxiliary_public_key = new Auxiliary.PublicKey(
             RECIPIENT_GUARDIAN_ID,
@@ -70,14 +68,14 @@ public class TestKeyCeremony {
     assertThat(backup.coefficient_commitments().size()).isEqualTo(QUORUM);
     assertThat(backup.coefficient_proofs().size()).isEqualTo(QUORUM);
     for (SchnorrProof proof : backup.coefficient_proofs()) {
-      assertThat(proof.is_valid(crypto_hash)).isTrue();
+      assertThat(proof.is_valid()).isTrue();
     }
   }
 
   @Example
   public void test_verify_election_partial_key_backup() {
     Auxiliary.KeyPair recipient_auxiliary_key_pair = generate_rsa_auxiliary_key_pair();
-    ElectionKeyPair sender_election_key_pair = generate_election_key_pair(QUORUM, null, crypto_hash);
+    ElectionKeyPair sender_election_key_pair = generate_election_key_pair(QUORUM, null);
     Auxiliary.PublicKey recipient_auxiliary_public_key = new Auxiliary.PublicKey(
             RECIPIENT_GUARDIAN_ID,
             RECIPIENT_SEQUENCE_ORDER,
@@ -105,7 +103,7 @@ public class TestKeyCeremony {
   @Example
   public void test_generate_election_partial_key_challenge() {
     Auxiliary.KeyPair recipient_auxiliary_key_pair = generate_rsa_auxiliary_key_pair();
-    ElectionKeyPair sender_election_key_pair = generate_election_key_pair(QUORUM, null, crypto_hash);
+    ElectionKeyPair sender_election_key_pair = generate_election_key_pair(QUORUM, null);
     Auxiliary.PublicKey recipient_auxiliary_public_key = new Auxiliary.PublicKey(
             RECIPIENT_GUARDIAN_ID,
             RECIPIENT_SEQUENCE_ORDER,
@@ -126,14 +124,14 @@ public class TestKeyCeremony {
     assertThat(challenge.coefficient_commitments().size()).isEqualTo(QUORUM);
     assertThat(challenge.coefficient_proofs().size()).isEqualTo(QUORUM);
     for (SchnorrProof proof : challenge.coefficient_proofs()) {
-      assertThat(proof.is_valid(crypto_hash)).isTrue();
+      assertThat(proof.is_valid()).isTrue();
     }
   }
 
   @Example
   public void test_verify_election_partial_key_challenge() {
     Auxiliary.KeyPair recipient_auxiliary_key_pair = generate_rsa_auxiliary_key_pair();
-    ElectionKeyPair sender_election_key_pair = generate_election_key_pair(QUORUM, null, crypto_hash);
+    ElectionKeyPair sender_election_key_pair = generate_election_key_pair(QUORUM, null);
     Auxiliary.PublicKey recipient_auxiliary_public_key = new Auxiliary.PublicKey(
             RECIPIENT_GUARDIAN_ID,
             RECIPIENT_SEQUENCE_ORDER,
@@ -158,8 +156,8 @@ public class TestKeyCeremony {
 
   @Example
   public void test_combine_election_public_keys() {
-    ElectionKeyPair random_keypair = generate_election_key_pair(QUORUM, null, crypto_hash);
-    ElectionKeyPair random_keypair_two = generate_election_key_pair(QUORUM, null, crypto_hash);
+    ElectionKeyPair random_keypair = generate_election_key_pair(QUORUM, null);
+    ElectionKeyPair random_keypair_two = generate_election_key_pair(QUORUM, null);
     Map<String, ElectionPublicKey> public_keys = new HashMap<>();
     public_keys.put(
             RECIPIENT_GUARDIAN_ID,

--- a/src/test/java/com/sunya/electionguard/TestKeyCeremonyMediator.java
+++ b/src/test/java/com/sunya/electionguard/TestKeyCeremonyMediator.java
@@ -8,10 +8,7 @@ import java.util.Optional;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
-
-import static com.sunya.electionguard.Group.rand_q;
 import static com.sunya.electionguard.KeyCeremony.*;
-
 
 public class TestKeyCeremonyMediator {
   private static final int NUMBER_OF_GUARDIANS = 2;
@@ -20,10 +17,9 @@ public class TestKeyCeremonyMediator {
   private static final String GUARDIAN_1_ID = "Guardian 1";
   private static final String GUARDIAN_2_ID = "Guardian 2";
   private static final String VERIFIER_ID = "Guardian 3";
-  private static Group.ElementModQ crypto_hash = rand_q();
-  private static final GuardianBuilder GUARDIAN_1 = GuardianBuilder.createForTesting(GUARDIAN_1_ID, 1, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash,null);
-  private static final GuardianBuilder GUARDIAN_2 = GuardianBuilder.createForTesting(GUARDIAN_2_ID, 2, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash, null);
-  private static final GuardianBuilder VERIFIER =   GuardianBuilder.createForTesting(VERIFIER_ID, 3, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash, null);
+  private static final GuardianBuilder GUARDIAN_1 = GuardianBuilder.createForTesting(GUARDIAN_1_ID, 1, NUMBER_OF_GUARDIANS, QUORUM,null);
+  private static final GuardianBuilder GUARDIAN_2 = GuardianBuilder.createForTesting(GUARDIAN_2_ID, 2, NUMBER_OF_GUARDIANS, QUORUM, null);
+  private static final GuardianBuilder VERIFIER =   GuardianBuilder.createForTesting(VERIFIER_ID, 3, NUMBER_OF_GUARDIANS, QUORUM, null);
 
   static Auxiliary.Decryptor identity_auxiliary_decrypt = (m, k) -> Optional.of(new String(m.getBytes()));
   static Auxiliary.Encryptor identity_auxiliary_encrypt = (m, k) -> Optional.of(new Auxiliary.ByteString(m.getBytes()));

--- a/src/test/java/com/sunya/electionguard/TestSchnorrProperties.java
+++ b/src/test/java/com/sunya/electionguard/TestSchnorrProperties.java
@@ -8,14 +8,13 @@ import static com.sunya.electionguard.Group.*;
 import static com.sunya.electionguard.SchnorrProof.*;
 
 public class TestSchnorrProperties extends TestProperties {
-  private static final ElementModQ crypto_hash = Group.rand_q();
 
   @Property
   public void test_schnorr_proofs_simple() {
     // doesn't get any simpler than this
     ElGamal.KeyPair keypair = ElGamal.elgamal_keypair_from_secret(TWO_MOD_Q).orElseThrow();
-    SchnorrProof proof = make_schnorr_proof(keypair, ONE_MOD_Q, crypto_hash);
-    assertThat(proof.is_valid(crypto_hash)).isTrue();
+    SchnorrProof proof = make_schnorr_proof(keypair, ONE_MOD_Q);
+    assertThat(proof.is_valid()).isTrue();
   }
 
   @Property
@@ -23,8 +22,8 @@ public class TestSchnorrProperties extends TestProperties {
           @ForAll("elgamal_keypairs") ElGamal.KeyPair keypair,
           @ForAll("elements_mod_q") Group.ElementModQ nonce) {
 
-    SchnorrProof proof = make_schnorr_proof(keypair, nonce, crypto_hash);
-    assertThat(proof.is_valid(crypto_hash)).isTrue();
+    SchnorrProof proof = make_schnorr_proof(keypair, nonce);
+    assertThat(proof.is_valid()).isTrue();
   }
 
   //// Introduce errors in the proofs and make sure that they fail to verify
@@ -35,10 +34,10 @@ public class TestSchnorrProperties extends TestProperties {
           @ForAll("elements_mod_q") Group.ElementModQ nonce,
           @ForAll("elements_mod_q") Group.ElementModQ other) {
 
-    SchnorrProof proof = make_schnorr_proof(keypair, nonce, crypto_hash);
+    SchnorrProof proof = make_schnorr_proof(keypair, nonce);
     assertThat(other).isNotEqualTo(proof.response); // otherwise wont fail
     SchnorrProof proof2 = new SchnorrProof(proof.public_key, proof.commitment, proof.challenge, other);
-    assertThat(proof2.is_valid(crypto_hash)).isFalse();
+    assertThat(proof2.is_valid()).isFalse();
   }
 
   @Property
@@ -47,10 +46,10 @@ public class TestSchnorrProperties extends TestProperties {
           @ForAll("elements_mod_q") Group.ElementModQ nonce,
           @ForAll("elements_mod_p_no_zero") Group.ElementModP other) {
 
-    SchnorrProof proof = make_schnorr_proof(keypair, nonce, crypto_hash);
+    SchnorrProof proof = make_schnorr_proof(keypair, nonce);
     assertThat(other).isNotEqualTo(proof.commitment); // otherwise wont fail
     SchnorrProof proof_bad = new SchnorrProof(proof.public_key, other, proof.challenge, proof.response);
-    assertThat(proof_bad.is_valid(crypto_hash)).isFalse();
+    assertThat(proof_bad.is_valid()).isFalse();
   }
 
   @Property
@@ -59,21 +58,21 @@ public class TestSchnorrProperties extends TestProperties {
           @ForAll("elements_mod_q") Group.ElementModQ nonce,
           @ForAll("elements_mod_p_no_zero") Group.ElementModP other) {
 
-    SchnorrProof proof = make_schnorr_proof(keypair, nonce, crypto_hash);
+    SchnorrProof proof = make_schnorr_proof(keypair, nonce);
     assertThat(other).isNotEqualTo(proof.public_key); // otherwise wont fail
     SchnorrProof proof2 = new SchnorrProof(other, proof.commitment, proof.challenge, proof.response);
-    assertThat(proof2.is_valid(crypto_hash)).isFalse();
+    assertThat(proof2.is_valid()).isFalse();
   }
 
   @Property
   public void test_schnorr_proofs_bounds_checking(
           @ForAll("elgamal_keypairs") ElGamal.KeyPair keypair,
           @ForAll("elements_mod_q") Group.ElementModQ nonce) {
-    SchnorrProof proof = make_schnorr_proof(keypair, nonce, crypto_hash);
+    SchnorrProof proof = make_schnorr_proof(keypair, nonce);
     SchnorrProof proof2 = new SchnorrProof(ZERO_MOD_P, proof.commitment, proof.challenge, proof.response);
     SchnorrProof proof3 = new SchnorrProof(int_to_p_unchecked(P), proof.commitment, proof.challenge, proof.response);
-    assertThat(proof2.is_valid(crypto_hash)).isFalse();
-    assertThat(proof3.is_valid(crypto_hash)).isFalse();
+    assertThat(proof2.is_valid()).isFalse();
+    assertThat(proof3.is_valid()).isFalse();
   }
 
 }

--- a/src/test/java/com/sunya/electionguard/TimeIntegrationSteps.java
+++ b/src/test/java/com/sunya/electionguard/TimeIntegrationSteps.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.common.truth.Truth8.assertThat;
 import static com.sunya.electionguard.Ballot.*;
 import static com.sunya.electionguard.Election.*;
-import static com.sunya.electionguard.Group.rand_q;
 import static com.sunya.electionguard.ElectionWithPlaceholders.ContestWithPlaceholders;
 
 import static org.junit.Assert.fail;
@@ -154,11 +153,10 @@ public class TimeIntegrationSteps {
    */
   void step_1_key_ceremony() {
     System.out.printf("%n1. Key Ceremony%n");
-    Group.ElementModQ crypto_hash = rand_q();
     // Setup Guardians
     for (int i = 0; i < NUMBER_OF_GUARDIANS; i++) {
       int sequence = i + 1;
-      this.guardianBuilders.add(GuardianBuilder.createForTesting("guardian_" + sequence, sequence, NUMBER_OF_GUARDIANS, QUORUM, crypto_hash, null));
+      this.guardianBuilders.add(GuardianBuilder.createForTesting("guardian_" + sequence, sequence, NUMBER_OF_GUARDIANS, QUORUM, null));
     }
 
     // Setup Mediator

--- a/src/test/java/com/sunya/electionguard/publish/TestPublish.java
+++ b/src/test/java/com/sunya/electionguard/publish/TestPublish.java
@@ -80,7 +80,7 @@ public class TestPublish {
                     Optional.of(int_to_q_unchecked(BigInteger.ZERO)), ImmutableList.of(), Optional.empty(),Optional.empty(), Optional.empty()));
 
     List<Guardian> guardians = ImmutableList.of(
-            GuardianBuilder.createForTesting("GuardianId", 1, 1, 1, rand_q(), null).build());
+            GuardianBuilder.createForTesting("GuardianId", 1, 1, 1, null).build());
 
     Publisher publisher = new Publisher(outputDir, false, false);
     publisher.publish_private_data(

--- a/src/test/java/com/sunya/electionguard/workflow/TestKeyCeremonySerializing.java
+++ b/src/test/java/com/sunya/electionguard/workflow/TestKeyCeremonySerializing.java
@@ -81,7 +81,7 @@ public class TestKeyCeremonySerializing {
 
     this.guardianBuilders = new ArrayList<>();
     for (KeyCeremony.CoefficientSet coeffSet : coefficientsProvider.guardianCoefficients()) {
-      this.guardianBuilders.add(GuardianBuilder.createRandom(coeffSet, numberOfGuardians, quorum, this.crypto_base_hash));
+      this.guardianBuilders.add(GuardianBuilder.createRandom(coeffSet, numberOfGuardians, quorum));
     }
 
     System.out.printf("%nKey Ceremony%n");
@@ -189,8 +189,7 @@ public class TestKeyCeremonySerializing {
             this.coefficientValidationSets);
 
     this.guardians = guardianBuilders.stream().map(GuardianBuilder::build).collect(Collectors.toList());
-    KeyCeremonyProto.Guardians guardianProto = KeyCeremonyToProto.convertGuardians(guardians,
-            this.quorum, this.crypto_base_hash);
+    KeyCeremonyProto.Guardians guardianProto = KeyCeremonyToProto.convertGuardians(guardians, this.quorum);
 
     publisher.writeGuardiansProto(guardianProto);
   }


### PR DESCRIPTION
Guardian SchnoorProof no longer needs crypto_base_hash (see Issue #278…, Spec 2A changed).