### PR TITLE
Port python PR #415 "CryptoHash using Sequence Order", issue #350

### DIFF
--- a/src/main/java/com/sunya/electionguard/CiphertextSelection.java
+++ b/src/main/java/com/sunya/electionguard/CiphertextSelection.java
@@ -1,28 +1,58 @@
 package com.sunya.electionguard;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 
 import javax.annotation.concurrent.Immutable;
+import java.util.Objects;
 
 /**
  * Superclass for encrypted selections.
  */
 @Immutable
-public class CiphertextSelection extends ElectionObjectBase {
+public class CiphertextSelection implements OrderedObjectBaseIF {
+  public final String object_id;
+  public final int sequence_order;
   /** Manifest.SelectionDescription.crypto_hash(). */
   public final Group.ElementModQ description_hash;
   private final ElGamal.Ciphertext ciphertext; // only accessed through ciphertext(), so subclass can override
   public final boolean is_placeholder;
 
-  CiphertextSelection(String object_id, Group.ElementModQ description_hash, ElGamal.Ciphertext ciphertext, boolean is_placeholder) {
-    super(object_id);
+  CiphertextSelection(String object_id, int sequence_order, Group.ElementModQ description_hash,
+                      ElGamal.Ciphertext ciphertext, boolean is_placeholder) {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(object_id));
+    this.object_id = object_id;
+    this.sequence_order = sequence_order;
     this.description_hash = Preconditions.checkNotNull(description_hash);
     this.ciphertext = Preconditions.checkNotNull(ciphertext);
     this.is_placeholder = is_placeholder;
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    CiphertextSelection that = (CiphertextSelection) o;
+    return sequence_order == that.sequence_order && is_placeholder == that.is_placeholder && object_id.equals(that.object_id) && description_hash.equals(that.description_hash) && ciphertext.equals(that.ciphertext);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(object_id, sequence_order, description_hash, ciphertext, is_placeholder);
+  }
+
   /** The encrypted vote count. */
   public ElGamal.Ciphertext ciphertext() {
     return ciphertext;
+  }
+
+  @Override
+  public String object_id() {
+    return object_id;
+  }
+
+  @Override
+  public int sequence_order() {
+    return sequence_order;
   }
 }

--- a/src/main/java/com/sunya/electionguard/CiphertextTally.java
+++ b/src/main/java/com/sunya/electionguard/CiphertextTally.java
@@ -1,5 +1,7 @@
 package com.sunya.electionguard;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.concurrent.Immutable;
@@ -30,15 +32,20 @@ public class CiphertextTally extends ElectionObjectBase {
    * The object_id is the Manifest.ContestDescription.object_id.
    */
   @Immutable
-  public static class Contest extends ElectionObjectBase {
+  public static class Contest implements OrderedObjectBaseIF {
+    public final String object_id;
+    public final int sequence_order;
+
     /** The ContestDescription crypto_hash. */
     public final ElementModQ contestDescriptionHash;
 
     /** The collection of selections in the contest, keyed by selection.object_id. */
     public final ImmutableMap<String, Selection> selections; // Map(SELECTION_ID, CiphertextTallySelection)
 
-    public Contest(String object_id, ElementModQ contestDescriptionHash, Map<String, Selection> selections) {
-      super(object_id);
+    public Contest(String object_id, int sequence_order, ElementModQ contestDescriptionHash, Map<String, Selection> selections) {
+      Preconditions.checkArgument(!Strings.isNullOrEmpty(object_id));
+      this.object_id = object_id;
+      this.sequence_order = sequence_order;
       this.contestDescriptionHash = contestDescriptionHash;
       this.selections = ImmutableMap.copyOf(selections);
     }
@@ -65,6 +72,16 @@ public class CiphertextTally extends ElectionObjectBase {
               "\n contestDescriptionHash=" + contestDescriptionHash +
               '}';
     }
+
+    @Override
+    public String object_id() {
+      return object_id;
+    }
+
+    @Override
+    public int sequence_order() {
+      return sequence_order;
+    }
   }
 
   /**
@@ -73,8 +90,8 @@ public class CiphertextTally extends ElectionObjectBase {
    */
   @Immutable
   public static class Selection extends CiphertextSelection {
-    public Selection(String selectionDescriptionId, ElementModQ description_hash, ElGamal.Ciphertext ciphertext) {
-      super(selectionDescriptionId, description_hash, ciphertext, false);
+    public Selection(String selectionDescriptionId, int sequence_order, ElementModQ description_hash, ElGamal.Ciphertext ciphertext) {
+      super(selectionDescriptionId, sequence_order, description_hash, ciphertext, false);
     }
 
     @Override

--- a/src/main/java/com/sunya/electionguard/CompactPlaintextBallot.java
+++ b/src/main/java/com/sunya/electionguard/CompactPlaintextBallot.java
@@ -98,13 +98,17 @@ public class CompactPlaintextBallot {
       for (Manifest.SelectionDescription selection: sortedSelections) {
         selections.add(
                 new PlaintextBallot.Selection(
-                        selection.object_id,
+                        selection.object_id(),
+                        selection.sequence_order(),
                         compact_ballot.selections.get(index) ? YES_VOTE : NO_VOTE,
                         placeholder,
                         compact_ballot.extended_data.get(index)));
         index += 1;
       }
-      contests.add(new PlaintextBallot.Contest(manifest_contest.object_id, selections));
+      contests.add(new PlaintextBallot.Contest(
+              manifest_contest.object_id(),
+              manifest_contest.sequence_order(),
+              selections));
     }
     return contests;
   }

--- a/src/main/java/com/sunya/electionguard/DecryptWithSecrets.java
+++ b/src/main/java/com/sunya/electionguard/DecryptWithSecrets.java
@@ -44,7 +44,8 @@ class DecryptWithSecrets {
     // TODO: ISSUE #47: handle decryption of the extra data field if needed
 
     return Optional.of(new PlaintextBallot.Selection(
-            selection.object_id,
+            selection.object_id(),
+            selection.sequence_order(),
             plaintext_vote,
             selection.is_placeholder_selection,
             null));
@@ -103,7 +104,8 @@ class DecryptWithSecrets {
     // TODO: ISSUE #35: encrypt/decrypt: handle decryption of the extradata field if needed
 
     return Optional.of(new PlaintextBallot.Selection(
-            selection.object_id,
+            selection.object_id(),
+            selection.sequence_order(),
             plaintext_vote,
             selection.is_placeholder_selection,
             null));
@@ -158,7 +160,10 @@ class DecryptWithSecrets {
       }
     }
 
-    return Optional.of(new PlaintextBallot.Contest(contest.object_id, plaintext_selections));
+    return Optional.of(new PlaintextBallot.Contest(
+            contest.object_id(),
+            contest.sequence_order(),
+            plaintext_selections));
   }
 
   /**
@@ -236,7 +241,10 @@ class DecryptWithSecrets {
       }
     }
 
-    return Optional.of(new PlaintextBallot.Contest(contest.object_id, plaintext_selections));
+    return Optional.of(new PlaintextBallot.Contest(
+            contest.object_id(),
+            contest.sequence_order(),
+            plaintext_selections));
   }
 
   /**

--- a/src/main/java/com/sunya/electionguard/DecryptWithShares.java
+++ b/src/main/java/com/sunya/electionguard/DecryptWithShares.java
@@ -203,7 +203,8 @@ public class DecryptWithShares {
     // [share for (guardian_id, (public_key, share))in shares.items()],
     List<DecryptionShare.CiphertextDecryptionSelection> selections = shares.values().stream().map(t -> t.decryption).collect(Collectors.toList());
     return Optional.of( PlaintextTally.Selection.create(
-            selection.object_id,
+            selection.object_id(),
+            selection.sequence_order(),
             dlogM,
             decrypted_value,
             selection.ciphertext(),

--- a/src/main/java/com/sunya/electionguard/Decryptions.java
+++ b/src/main/java/com/sunya/electionguard/Decryptions.java
@@ -174,7 +174,7 @@ class Decryptions {
       if (tuple.proof.is_valid(selection.ciphertext(), guardian_keys.key_pair().public_key,
               tuple.decryption, context.crypto_extended_base_hash)) {
         return Optional.of(DecryptionShare.create_ciphertext_decryption_selection(
-                selection.object_id,
+                selection.object_id(),
                 guardian_keys.owner_id(),
                 tuple.decryption,
                 Optional.of(tuple.proof),
@@ -658,7 +658,7 @@ class Decryptions {
         Group.ElementModP reconstructed_share = Group.mult_p(share_pow_p);
 
         selections.put(selection.object_id, create_ciphertext_decryption_selection(
-                selection.object_id,
+                selection.object_id(),
                 missing_guardian_id,
                 reconstructed_share,
                 Optional.empty(),

--- a/src/main/java/com/sunya/electionguard/ElGamal.java
+++ b/src/main/java/com/sunya/electionguard/ElGamal.java
@@ -169,7 +169,7 @@ public class ElGamal {
   /**
    * Encrypts a message with a given random nonce and an ElGamal public key.
    *
-   * @param message    Message to elgamal_encrypt; must be an integer in [0,Q).
+   * @param message    must be an integer in [0,Q).
    * @param nonce      Randomly chosen nonce in [1,Q).
    * @param public_key ElGamal public key.
    * @return An ElGamal.Ciphertext.

--- a/src/main/java/com/sunya/electionguard/Encrypt.java
+++ b/src/main/java/com/sunya/electionguard/Encrypt.java
@@ -102,28 +102,28 @@ public class Encrypt {
    * This function is useful for filling selections when a voter undervotes a ballot.
    * It is also used to create placeholder representations when generating the `ConstantChaumPedersenProof`
    *
-   * @param description:    The `SelectionDescription` which provides the relevant `object_id`
+   * @param mselection:    The `SelectionDescription` which provides the relevant `object_id`
    * @param is_placeholder: Mark this selection as a placeholder value
    * @param is_affirmative: Mark this selection as `yes`
    */
   // selection_from( description: SelectionDescription, is_placeholder: bool = False, is_affirmative: bool = False,
-  static PlaintextBallot.Selection selection_from(Manifest.SelectionDescription description, boolean is_placeholder, boolean is_affirmative) {
-    return new PlaintextBallot.Selection(description.object_id, is_affirmative ? 1 : 0, is_placeholder, null);
+  static PlaintextBallot.Selection selection_from(Manifest.SelectionDescription mselection, boolean is_placeholder, boolean is_affirmative) {
+    return new PlaintextBallot.Selection(mselection.object_id(), mselection.sequence_order(), is_affirmative ? 1 : 0, is_placeholder, null);
   }
 
   /**
    * Construct a `BallotContest` from a specific `ContestDescription` with all false fields.
    * This function is useful for filling contests and selections when a voter undervotes a ballot.
    *
-   * @param description: The `ContestDescription` used to derive the well-formed `BallotContest`
+   * @param mcontest: The `ContestDescription` used to derive the well-formed `BallotContest`
    */
-  static PlaintextBallot.Contest contest_from(Manifest.ContestDescription description) {
+  static PlaintextBallot.Contest contest_from(Manifest.ContestDescription mcontest) {
     List<PlaintextBallot.Selection> selections = new ArrayList<>();
 
-    for (Manifest.SelectionDescription selection_description : description.ballot_selections) {
+    for (Manifest.SelectionDescription selection_description : mcontest.ballot_selections) {
       selections.add(selection_from(selection_description, false, false));
     }
-    return new PlaintextBallot.Contest(description.object_id, selections);
+    return new PlaintextBallot.Contest(mcontest.object_id(), mcontest.sequence_order(), selections);
   }
 
   /**
@@ -174,6 +174,7 @@ public class Encrypt {
 
     CiphertextBallot.Selection encrypted_selection = CiphertextBallot.Selection.create(
             selection.selection_id,
+            selection.sequence_order,
             selection_description_hash,
             elgamal_encryption.get(),
             elgamal_public_key,
@@ -326,6 +327,7 @@ public class Encrypt {
 
     CiphertextBallot.Contest encrypted_contest = CiphertextBallot.Contest.create(
         contest.contest_id,
+        contest.sequence_order,
         contest_description_hash,
         encrypted_selections,
         elgamal_public_key,

--- a/src/main/java/com/sunya/electionguard/Manifest.java
+++ b/src/main/java/com/sunya/electionguard/Manifest.java
@@ -899,7 +899,8 @@ public class Manifest implements Hash.CryptoHashable {
    * @see <a href="https://developers.google.com/elections-data/reference/ballot-selection">Civics Common Standard Data Specification</a>
    */
   @Immutable
-  public static class SelectionDescription extends ElectionObjectBase implements Hash.CryptoHashable {
+  public static class SelectionDescription implements OrderedObjectBaseIF, Hash.CryptoHashable {
+    public final String object_id;
     public final String candidate_id;
     /**
      * Used for ordering selections in a contest to ensure various encryption primitives are deterministic.
@@ -910,10 +911,11 @@ public class Manifest implements Hash.CryptoHashable {
     public final int sequence_order;
 
     public SelectionDescription(String object_id, String candidate_id, int sequence_order) {
-      super(object_id);
+      Preconditions.checkArgument(!Strings.isNullOrEmpty(object_id));
+      this.object_id = object_id;
+      this.sequence_order = sequence_order;
       Preconditions.checkArgument(!Strings.isNullOrEmpty(candidate_id));
       this.candidate_id = candidate_id;
-      this.sequence_order = sequence_order;
     }
 
     @Override
@@ -925,27 +927,33 @@ public class Manifest implements Hash.CryptoHashable {
     public boolean equals(Object o) {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
-      if (!super.equals(o)) return false;
       SelectionDescription that = (SelectionDescription) o;
-      return sequence_order == that.sequence_order &&
-              candidate_id.equals(that.candidate_id);
+      return sequence_order == that.sequence_order && object_id.equals(that.object_id) && candidate_id.equals(that.candidate_id);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(super.hashCode(), candidate_id, sequence_order);
+      return Objects.hash(object_id, candidate_id, sequence_order);
     }
 
     @Override
     public String toString() {
       return "SelectionDescription{" +
-              "\n object_id='" + object_id + '\'' +
-              "\n candidate_id='" + candidate_id + '\'' +
-              "\n sequence_order=" + sequence_order +
+              "object_id='" + object_id + '\'' +
+              ", candidate_id='" + candidate_id + '\'' +
+              ", sequence_order=" + sequence_order +
               '}';
     }
 
+    @Override
+    public String object_id() {
+      return object_id;
+    }
 
+    @Override
+    public int sequence_order() {
+      return sequence_order;
+    }
   }
 
   /**
@@ -953,9 +961,12 @@ public class Manifest implements Hash.CryptoHashable {
    * @see <a href="https://developers.google.com/elections-data/reference/contest">Civics Common Standard Data Specification</a>
    */
   @Immutable
-  public static class ContestDescription extends ElectionObjectBase implements Hash.CryptoHashable {
+  public static class ContestDescription implements OrderedObjectBaseIF, Hash.CryptoHashable {
+
+    public final String object_id;
 
     public final String electoral_district_id;
+
     /**
      * Used for ordering contests in a ballot to ensure various encryption primitives are deterministic.
      * The sequence order must be unique and should be representative of how the contests are represented
@@ -996,10 +1007,13 @@ public class Manifest implements Hash.CryptoHashable {
                               List<SelectionDescription> ballot_selections,
                               @Nullable InternationalizedText ballot_title,
                               @Nullable InternationalizedText ballot_subtitle) {
-      super(object_id);
-      Preconditions.checkArgument(!Strings.isNullOrEmpty(electoral_district_id));
 
+      Preconditions.checkArgument(!Strings.isNullOrEmpty(object_id));
+      this.object_id = object_id;
+
+      Preconditions.checkArgument(!Strings.isNullOrEmpty(electoral_district_id));
       this.electoral_district_id = electoral_district_id;
+
       this.sequence_order = sequence_order;
       this.vote_variation = Preconditions.checkNotNull(vote_variation);
       this.number_elected = number_elected;
@@ -1014,36 +1028,28 @@ public class Manifest implements Hash.CryptoHashable {
     public boolean equals(Object o) {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
-      if (!super.equals(o)) return false;
       ContestDescription that = (ContestDescription) o;
-      return sequence_order == that.sequence_order &&
-              number_elected == that.number_elected &&
-              electoral_district_id.equals(that.electoral_district_id) &&
-              vote_variation == that.vote_variation &&
-              votes_allowed.equals(that.votes_allowed) &&
-              name.equals(that.name) &&
-              ballot_selections.equals(that.ballot_selections) &&
-              ballot_title.equals(that.ballot_title) &&
-              ballot_subtitle.equals(that.ballot_subtitle);
+      return sequence_order == that.sequence_order && number_elected == that.number_elected && object_id.equals(that.object_id) && electoral_district_id.equals(that.electoral_district_id) && vote_variation == that.vote_variation && votes_allowed.equals(that.votes_allowed) && name.equals(that.name) && ballot_selections.equals(that.ballot_selections) && ballot_title.equals(that.ballot_title) && ballot_subtitle.equals(that.ballot_subtitle);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(super.hashCode(), electoral_district_id, sequence_order, vote_variation, number_elected, votes_allowed, name, ballot_selections, ballot_title, ballot_subtitle);
+      return Objects.hash(object_id, electoral_district_id, sequence_order, vote_variation, number_elected, votes_allowed, name, ballot_selections, ballot_title, ballot_subtitle);
     }
 
     @Override
     public String toString() {
       return "ContestDescription{" +
-              "\n object_id='" + object_id + '\'' +
-              "\n electoral_district_id='" + electoral_district_id + '\'' +
-              "\n sequence_order=" + sequence_order +
-              "\n vote_variation=" + vote_variation +
-              "\n number_elected=" + number_elected +
-              "\n votes_allowed=" + votes_allowed +
-              "\n name='" + name + '\'' +
-              "\n ballot_title=" + ballot_title +
-              "\n ballot_subtitle=" + ballot_subtitle +
+              "object_id='" + object_id + '\'' +
+              ", electoral_district_id='" + electoral_district_id + '\'' +
+              ", sequence_order=" + sequence_order +
+              ", vote_variation=" + vote_variation +
+              ", number_elected=" + number_elected +
+              ", votes_allowed=" + votes_allowed +
+              ", name='" + name + '\'' +
+              ", ballot_selections=" + ballot_selections +
+              ", ballot_title=" + ballot_title +
+              ", ballot_subtitle=" + ballot_subtitle +
               '}';
     }
 
@@ -1104,6 +1110,16 @@ public class Manifest implements Hash.CryptoHashable {
       }
 
       return success;
+    }
+
+    @Override
+    public String object_id() {
+      return object_id;
+    }
+
+    @Override
+    public int sequence_order() {
+      return sequence_order;
     }
   }
 

--- a/src/main/java/com/sunya/electionguard/OrderedObjectBaseIF.java
+++ b/src/main/java/com/sunya/electionguard/OrderedObjectBaseIF.java
@@ -1,0 +1,6 @@
+package com.sunya.electionguard;
+
+/** Election objects that are identifiable by object_id and have a sequence ordering to sort on */
+public interface OrderedObjectBaseIF extends ElectionObjectBaseIF {
+  int sequence_order();
+}

--- a/src/main/java/com/sunya/electionguard/PlaintextBallot.java
+++ b/src/main/java/com/sunya/electionguard/PlaintextBallot.java
@@ -85,12 +85,14 @@ public class PlaintextBallot extends ElectionObjectBase {
   public static class Contest {
     /** The ContestDescription.object_id. */
     public final String contest_id;
+    public final int sequence_order;
     /** The Collection of ballot selections. */
     public final ImmutableList<Selection> ballot_selections;
 
-    public Contest(String contest_id, List<Selection> ballot_selections) {
+    public Contest(String contest_id, int sequence_order, List<Selection> ballot_selections) {
       Preconditions.checkArgument(!Strings.isNullOrEmpty(contest_id));
       this.contest_id = contest_id;
+      this.sequence_order = sequence_order;
       this.ballot_selections = ImmutableList.copyOf(ballot_selections);
     }
 
@@ -174,6 +176,7 @@ public class PlaintextBallot extends ElectionObjectBase {
   public static class Selection {
     /** Matches the SelectionDescription.object_id. */
     public final String selection_id;
+    public final int sequence_order;
     /** The vote count. */
     public final int vote;
     /** Is this a placeholder? */
@@ -181,10 +184,11 @@ public class PlaintextBallot extends ElectionObjectBase {
     /** Optional write-in candidate. */
     public final Optional<ExtendedData> extended_data; // default None
 
-    public Selection(String selection_id, int vote, boolean is_placeholder_selection,
+    public Selection(String selection_id, int sequence_order, int vote, boolean is_placeholder_selection,
                      @Nullable ExtendedData extended_data) {
       Preconditions.checkArgument(!Strings.isNullOrEmpty(selection_id));
       this.selection_id = selection_id;
+      this.sequence_order = sequence_order;
       this.vote = vote;
       this.is_placeholder_selection = is_placeholder_selection;
       this.extended_data = Optional.ofNullable(extended_data);
@@ -276,10 +280,10 @@ public class PlaintextBallot extends ElectionObjectBase {
       for (CiphertextBallot.Selection cselection : ccontest.ballot_selections) {
         if (!cselection.is_placeholder_selection) {
           PlaintextTally.Selection tselection = tcontest.selections().get(cselection.object_id);
-          selections.add(new Selection(cselection.object_id, tselection.tally(), false, null));
+          selections.add(new Selection(cselection.object_id, tselection.sequence_order(), tselection.tally(), false, null));
         }
       }
-      contests.add(new Contest(ccontest.object_id, selections));
+      contests.add(new Contest(ccontest.object_id(), ccontest.sequence_order(), selections));
     }
     return new PlaintextBallot(cballot.object_id, cballot.style_id, contests);
   }

--- a/src/main/java/com/sunya/electionguard/PlaintextTally.java
+++ b/src/main/java/com/sunya/electionguard/PlaintextTally.java
@@ -70,9 +70,10 @@ public class PlaintextTally {
   /**
    * The plaintext representation of the counts of one selection of one contest in the election.
    * The object_id is the same as the encrypted selection (Ballot.CiphertextSelection) object_id.
+   * TODO: Does CiphertextTallySelection really need to be ordered?
    */
   @AutoValue
-  public static abstract class Selection implements ElectionObjectBaseIF {
+  public static abstract class Selection implements OrderedObjectBaseIF {
     /** The actual count. */
     public abstract Integer tally();
     /** g^tally or M in the spec. */
@@ -83,10 +84,11 @@ public class PlaintextTally {
     /** The Guardians' shares of the decryption of a selection. `M_i` in the spec. Must be nguardians of them. */
     public abstract ImmutableList<DecryptionShare.CiphertextDecryptionSelection> shares();
 
-    public static Selection create(String object_id, Integer tally, ElementModP value, ElGamal.Ciphertext message,
+    public static Selection create(String object_id, int sequence_order, Integer tally, ElementModP value, ElGamal.Ciphertext message,
                                    List<DecryptionShare.CiphertextDecryptionSelection> shares) {
       return new AutoValue_PlaintextTally_Selection(
               Preconditions.checkNotNull(object_id),
+              sequence_order,
               Preconditions.checkNotNull(tally),
               Preconditions.checkNotNull(value),
               Preconditions.checkNotNull(message),
@@ -96,8 +98,8 @@ public class PlaintextTally {
     @Override
     public String toString() {
       Formatter f = new Formatter();
-      f.format("Selection{%n object_id= '%s'%n tally    = %d%n value    = %s%n message  = %s%n shares=%n",
-              object_id(), tally(), value().toShortString(), message());
+      f.format("Selection{%n object_id= '%s'%n sequence_order = %d%n tally    = %d%n value    = %s%n message  = %s%n shares=%n",
+              object_id(), sequence_order(), tally(), value().toShortString(), message());
       for (DecryptionShare.CiphertextDecryptionSelection sel : shares()) {
         f.format("   %s share = %s", sel.guardian_id(), sel.share().toShortString());
         if (sel.proof().isPresent()) {

--- a/src/main/java/com/sunya/electionguard/SubmittedBallot.java
+++ b/src/main/java/com/sunya/electionguard/SubmittedBallot.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.flogger.FluentLogger;
 
 import javax.annotation.concurrent.Immutable;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -46,7 +47,12 @@ public class SubmittedBallot extends CiphertextBallot {
       logger.atInfo().log("ciphertext ballot with no contest: %s", object_id);
     }
 
-    List<Group.ElementModQ> contest_hashes = contests.stream().map(c -> c.crypto_hash).collect(Collectors.toList());
+    // contest_hashes = [contest.crypto_hash for contest in sequence_order_sort(contests)]
+    List<Group.ElementModQ> contest_hashes = contests.stream()
+            .sorted(Comparator.comparingInt(CiphertextBallot.Contest::sequence_order))
+            .map(c -> c.crypto_hash)
+            .collect(Collectors.toList());
+
     Group.ElementModQ contest_hash = Hash.hash_elems(object_id, manifest_hash, contest_hashes);
 
     long timestamp = timestampO.orElse(System.currentTimeMillis());

--- a/src/main/java/com/sunya/electionguard/decrypting/RemoteDecryptions.java
+++ b/src/main/java/com/sunya/electionguard/decrypting/RemoteDecryptions.java
@@ -66,7 +66,7 @@ public class RemoteDecryptions {
                 tuple.decryption, context.crypto_extended_base_hash)) {
 
           CiphertextDecryptionSelection share = DecryptionShare.create_ciphertext_decryption_selection(
-                  tallySelection.object_id,
+                  tallySelection.object_id(),
                   guardian.id(),
                   tuple.decryption,
                   Optional.of(tuple.proof),
@@ -140,7 +140,7 @@ public class RemoteDecryptions {
                 tuple.decryption, context.crypto_extended_base_hash)) {
 
           CiphertextDecryptionSelection share = DecryptionShare.create_ciphertext_decryption_selection(
-                  ballotSelection.object_id,
+                  ballotSelection.object_id(),
                   guardian.id(),
                   tuple.decryption,
                   Optional.of(tuple.proof),
@@ -423,7 +423,7 @@ public class RemoteDecryptions {
       Group.ElementModP reconstructed_share = Group.mult_p(share_pow_p);
 
       selections.put(selection.object_id, DecryptionShare.create_ciphertext_decryption_selection(
-              selection.object_id,
+              selection.object_id(),
               missing_guardian_id,
               reconstructed_share,
               Optional.empty(),

--- a/src/main/java/com/sunya/electionguard/proto/CiphertextBallotFromProto.java
+++ b/src/main/java/com/sunya/electionguard/proto/CiphertextBallotFromProto.java
@@ -44,6 +44,7 @@ public class CiphertextBallotFromProto {
   static CiphertextBallot.Contest convertContest(CiphertextBallotProto.CiphertextBallotContest contest) {
     return new CiphertextBallot.Contest(
             contest.getObjectId(),
+            contest.getSequenceOrder(),
             convertElementModQ(contest.getDescriptionHash()),
             convertList(contest.getSelectionsList(), CiphertextBallotFromProto::convertSelection),
             convertElementModQ(contest.getCryptoHash()),
@@ -55,6 +56,7 @@ public class CiphertextBallotFromProto {
   static CiphertextBallot.Selection convertSelection(CiphertextBallotProto.CiphertextBallotSelection selection) {
     return new CiphertextBallot.Selection(
             selection.getObjectId(),
+            selection.getSequenceOrder(),
             convertElementModQ(selection.getDescriptionHash()),
             convertCiphertext(selection.getCiphertext()),
             convertElementModQ(selection.getCryptoHash()),

--- a/src/main/java/com/sunya/electionguard/proto/CiphertextTallyFromProto.java
+++ b/src/main/java/com/sunya/electionguard/proto/CiphertextTallyFromProto.java
@@ -28,6 +28,7 @@ public class CiphertextTallyFromProto {
 
     return new CiphertextTally.Contest(
             proto.getObjectId(),
+            proto.getSequenceOrder(),
             convertElementModQ(proto.getDescriptionHash()),
             selections);
   }
@@ -36,6 +37,7 @@ public class CiphertextTallyFromProto {
 
     return new CiphertextTally.Selection(
             proto.getObjectId(),
+            proto.getSequenceOrder(),
             convertElementModQ(proto.getDescriptionHash()),
             convertCiphertext(proto.getCiphertext()));
   }

--- a/src/main/java/com/sunya/electionguard/proto/PlaintextBallotFromProto.java
+++ b/src/main/java/com/sunya/electionguard/proto/PlaintextBallotFromProto.java
@@ -18,12 +18,14 @@ public class PlaintextBallotFromProto {
   static PlaintextBallot.Contest convertContest(PlaintextBallotProto.PlaintextBallotContest contest) {
     return new PlaintextBallot.Contest(
             contest.getContestId(),
+            contest.getSequenceOrder(),
             convertList(contest.getBallotSelectionsList(), PlaintextBallotFromProto::convertSelection));
   }
 
   static PlaintextBallot.Selection convertSelection(PlaintextBallotProto.PlaintextBallotSelection selection) {
     return new PlaintextBallot.Selection(
             selection.getSelectionId(),
+            selection.getSequenceOrder(),
             selection.getVote(),
             selection.getIsPlaceholderSelection(),
             selection.hasExtendedData() ? convertExtendedData(selection.getExtendedData()) : null);

--- a/src/main/java/com/sunya/electionguard/proto/PlaintextTallyFromProto.java
+++ b/src/main/java/com/sunya/electionguard/proto/PlaintextTallyFromProto.java
@@ -43,6 +43,7 @@ public class PlaintextTallyFromProto {
 
     return PlaintextTally.Selection.create(
             proto.getObjectId(),
+            proto.getSequenceOrder(),
             proto.getTally(),
             convertElementModP(proto.getValue()),
             convertCiphertext(proto.getMessage()),

--- a/src/main/java/com/sunya/electionguard/publish/CiphertextTallyPojo.java
+++ b/src/main/java/com/sunya/electionguard/publish/CiphertextTallyPojo.java
@@ -18,12 +18,14 @@ public class CiphertextTallyPojo {
 
   public static class CiphertextTallyContestPojo {
     public String object_id;
+    public int sequence_order;
     public Group.ElementModQ description_hash;
     public Map<String, CiphertextTallySelectionPojo> selections;
   }
 
   public static class CiphertextTallySelectionPojo {
     public String object_id;
+    public int sequence_order;
     public Group.ElementModQ description_hash;
     public ElGamal.Ciphertext ciphertext;
   }
@@ -55,6 +57,7 @@ public class CiphertextTallyPojo {
     }
     return new CiphertextTally.Contest(
             pojo.object_id,
+            pojo.sequence_order,
             pojo.description_hash,
             selections);
   }
@@ -64,6 +67,7 @@ public class CiphertextTallyPojo {
     //     @Nullable ElGamal.Ciphertext ciphertext) {
     return new CiphertextTally.Selection(
             pojo.object_id,
+            pojo.sequence_order,
             pojo.description_hash,
             pojo.ciphertext);
   }
@@ -97,6 +101,7 @@ public class CiphertextTallyPojo {
     }
     CiphertextTallyContestPojo pojo = new CiphertextTallyContestPojo();
     pojo.object_id = org.object_id;
+    pojo.sequence_order = org.sequence_order;
     pojo.description_hash = org.contestDescriptionHash;
     pojo.selections = selections;
     return pojo;
@@ -105,6 +110,7 @@ public class CiphertextTallyPojo {
   private static CiphertextTallySelectionPojo convertSelection(CiphertextTally.Selection org) {
     CiphertextTallySelectionPojo pojo = new CiphertextTallySelectionPojo();
     pojo.object_id = org.object_id;
+    pojo.sequence_order = org.sequence_order;
     pojo.description_hash = org.description_hash;
     pojo.ciphertext = org.ciphertext();
     return pojo;

--- a/src/main/java/com/sunya/electionguard/publish/PlaintextBallotPojo.java
+++ b/src/main/java/com/sunya/electionguard/publish/PlaintextBallotPojo.java
@@ -25,11 +25,13 @@ public class PlaintextBallotPojo {
 
   public static class PlaintextBallotContest {
     public String object_id;
+    public int sequence_order;
     public List<PlaintextBallotSelection> ballot_selections;
   }
 
   public static class PlaintextBallotSelection {
     public String object_id;
+    public int sequence_order;
     public int vote;
     public boolean is_placeholder_selection;
     // public String extra_data; // optional
@@ -80,6 +82,7 @@ public class PlaintextBallotPojo {
   private static PlaintextBallot.Contest convertPlaintextBallotContest(PlaintextBallotPojo.PlaintextBallotContest pojo) {
     return new PlaintextBallot.Contest(
             pojo.object_id,
+            pojo.sequence_order,
             convertList(pojo.ballot_selections, PlaintextBallotPojo::convertPlaintextBallotSelection));
   }
 
@@ -89,6 +92,7 @@ public class PlaintextBallotPojo {
 
     return new PlaintextBallot.Selection(
             pojo.object_id,
+            pojo.sequence_order,
             pojo.vote,
             pojo.is_placeholder_selection,
             null);
@@ -114,6 +118,7 @@ public class PlaintextBallotPojo {
   private static PlaintextBallotPojo.PlaintextBallotContest convertPlaintextBallotContest(PlaintextBallot.Contest src) {
     PlaintextBallotPojo.PlaintextBallotContest pojo = new PlaintextBallotPojo.PlaintextBallotContest ();
     pojo.object_id = src.contest_id;
+    pojo.sequence_order = src.sequence_order;
     pojo.ballot_selections = convertList(src.ballot_selections, PlaintextBallotPojo::convertPlaintextBallotSelection);
     return pojo;
   }
@@ -121,6 +126,7 @@ public class PlaintextBallotPojo {
   private static PlaintextBallotPojo.PlaintextBallotSelection convertPlaintextBallotSelection(PlaintextBallot.Selection src) {
     PlaintextBallotPojo.PlaintextBallotSelection pojo = new PlaintextBallotPojo.PlaintextBallotSelection ();
     pojo.object_id = src.selection_id;
+    pojo.sequence_order = src.sequence_order;
     pojo.vote = src.vote;
     pojo.is_placeholder_selection = src.is_placeholder_selection;
     // src.extended_data.ifPresent( data -> pojo.extra_data = data.value);

--- a/src/main/java/com/sunya/electionguard/publish/PlaintextTallyPojo.java
+++ b/src/main/java/com/sunya/electionguard/publish/PlaintextTallyPojo.java
@@ -25,11 +25,13 @@ public class PlaintextTallyPojo {
 
   public static class PlaintextTallyContestPojo {
     public String object_id;
+    public int sequence_order;
     public Map<String, PlaintextTallySelectionPojo> selections;
   }
 
   public static class PlaintextTallySelectionPojo {
     public String object_id;
+    public int sequence_order;
     public Integer tally;
     public Group.ElementModP value;
     public ElGamal.Ciphertext message;
@@ -97,6 +99,7 @@ public class PlaintextTallyPojo {
   private static PlaintextTally.Selection translateSelection(PlaintextTallySelectionPojo pojo) {
     return PlaintextTally.Selection.create(
             pojo.object_id,
+            pojo.sequence_order,
             pojo.tally,
             pojo.value,
             pojo.message,
@@ -177,6 +180,7 @@ public class PlaintextTallyPojo {
   private static PlaintextTallySelectionPojo convertSelection(PlaintextTally.Selection org) {
     PlaintextTallySelectionPojo pojo = new PlaintextTallySelectionPojo();
     pojo.object_id = org.object_id();
+    pojo.sequence_order = org.sequence_order();
     pojo.tally = org.tally();
     pojo.value = org.value();
     pojo.message = org.message();

--- a/src/main/java/com/sunya/electionguard/publish/SubmittedBallotPojo.java
+++ b/src/main/java/com/sunya/electionguard/publish/SubmittedBallotPojo.java
@@ -35,6 +35,7 @@ public class SubmittedBallotPojo {
 
   public static class CiphertextBallotContestPojo {
     public String object_id;
+    public int sequence_order;
     public ElementModQ description_hash;
     public List<CiphertextBallotSelectionPojo> ballot_selections;
     public ElementModQ crypto_hash;
@@ -45,6 +46,7 @@ public class SubmittedBallotPojo {
 
   public static class CiphertextBallotSelectionPojo {
     public String object_id;
+    public int sequence_order;
     public ElementModQ description_hash;
     public ElGamalCiphertextPojo ciphertext;
     public ElementModQ crypto_hash;
@@ -110,6 +112,7 @@ public class SubmittedBallotPojo {
   private static CiphertextBallot.Contest translateContest(CiphertextBallotContestPojo contest) {
     return new CiphertextBallot.Contest(
             contest.object_id,
+            contest.sequence_order,
             contest.description_hash,
             convertList(contest.ballot_selections, SubmittedBallotPojo::translateSelection),
             contest.crypto_hash,
@@ -121,6 +124,7 @@ public class SubmittedBallotPojo {
   private static CiphertextBallot.Selection translateSelection(CiphertextBallotSelectionPojo selection) {
     return new CiphertextBallot.Selection(
             selection.object_id,
+            selection.sequence_order,
             selection.description_hash,
             translateCiphertext(selection.ciphertext),
             selection.crypto_hash,
@@ -197,7 +201,8 @@ public class SubmittedBallotPojo {
 
   private static CiphertextBallotContestPojo convertContest(CiphertextBallot.Contest contest) {
     CiphertextBallotContestPojo pojo = new CiphertextBallotContestPojo();
-    pojo.object_id = contest.object_id;
+    pojo.object_id = contest.object_id();
+    pojo.sequence_order = contest.sequence_order();
     pojo.description_hash = contest.contest_hash;
     pojo.ballot_selections = convertList(contest.ballot_selections, SubmittedBallotPojo::convertSelection);
     pojo.crypto_hash = contest.crypto_hash;
@@ -209,7 +214,8 @@ public class SubmittedBallotPojo {
 
   private static CiphertextBallotSelectionPojo convertSelection(CiphertextBallot.Selection selection) {
     CiphertextBallotSelectionPojo pojo = new CiphertextBallotSelectionPojo();
-    pojo.object_id = selection.object_id;
+    pojo.object_id = selection.object_id();
+    pojo.sequence_order = selection.sequence_order();
     pojo.description_hash = selection.description_hash;
     pojo.ciphertext = convertCiphertext(selection.ciphertext());
     pojo.crypto_hash = selection.crypto_hash;

--- a/src/main/java/com/sunya/electionguard/simulate/TrusteeDecryptions.java
+++ b/src/main/java/com/sunya/electionguard/simulate/TrusteeDecryptions.java
@@ -167,7 +167,7 @@ public class TrusteeDecryptions {
       if (tuple.proof.is_valid(selection.ciphertext(), guardian.electionPublicKey(),
               tuple.decryption, context.crypto_extended_base_hash)) {
         return Optional.of(DecryptionShare.create_ciphertext_decryption_selection(
-                selection.object_id,
+                selection.object_id(),
                 guardian.id(),
                 tuple.decryption,
                 Optional.of(tuple.proof),
@@ -412,7 +412,7 @@ public class TrusteeDecryptions {
         Group.ElementModP reconstructed_share = Group.mult_p(share_pow_p);
 
         selections.put(selection.object_id, DecryptionShare.create_ciphertext_decryption_selection(
-                selection.object_id,
+                selection.object_id(),
                 missing_guardian_id,
                 reconstructed_share,
                 Optional.empty(),

--- a/src/main/java/com/sunya/electionguard/workflow/FakeBallotProvider.java
+++ b/src/main/java/com/sunya/electionguard/workflow/FakeBallotProvider.java
@@ -58,12 +58,16 @@ public class FakeBallotProvider implements BallotProvider {
           selections.add(selection);
         }
       }
-      return new PlaintextBallot.Contest(contest.object_id, selections);
+      return new PlaintextBallot.Contest(
+              contest.object_id(),
+              contest.sequence_order(),
+              selections);
     }
 
     static PlaintextBallot.Selection get_random_selection_from(Manifest.SelectionDescription description) {
       boolean choice = random.nextBoolean();
-      return new PlaintextBallot.Selection(description.object_id, choice ? 1 : 0, false, null);
+      return new PlaintextBallot.Selection(description.object_id(), description.sequence_order(),
+              choice ? 1 : 0, false, null);
     }
 
   }

--- a/src/main/proto/com/sunya/electionguard/protogen/ciphertext_ballot.proto
+++ b/src/main/proto/com/sunya/electionguard/protogen/ciphertext_ballot.proto
@@ -33,6 +33,7 @@ message CiphertextBallot {
 // Encrypted selections for a specific contest.
 message CiphertextBallotContest {
   string object_id = 1; // matches the ContestDescription.object_id
+  int32 sequence_order = 8; // matches the ContestDescription.object_id
   ElementModQ description_hash = 2; // Hash of the contest description
   repeated CiphertextBallotSelection selections = 3;
   ElementModQ crypto_hash = 4; // The hash of the encrypted values
@@ -45,6 +46,7 @@ message CiphertextBallotContest {
 // Encryption of a specific selection.
 message CiphertextBallotSelection {
   string object_id = 1;
+  int32 sequence_order = 9; // matches the ContestDescription.object_id
   ElementModQ description_hash = 2; // Hash of the selection description
   ElGamalCiphertext ciphertext = 3; // The encrypted representation of the vote field
   ElementModQ crypto_hash = 4; // The hash of the encrypted values

--- a/src/main/proto/com/sunya/electionguard/protogen/ciphertext_tally.proto
+++ b/src/main/proto/com/sunya/electionguard/protogen/ciphertext_tally.proto
@@ -15,6 +15,7 @@ message CiphertextTally {
 
 message CiphertextTallyContest {
   string object_id = 1;
+  int32 sequence_order = 4;
 
   // The ContestDescription hash.
   ElementModQ description_hash = 2;
@@ -26,6 +27,7 @@ message CiphertextTallyContest {
 // A homomorphic accumulation of CiphertextBallotSelections.
 message CiphertextTallySelection {
   string object_id = 1;
+  int32 sequence_order = 4;
   ElementModQ description_hash = 2;
   // accumulation over all the cast ballots
   ElGamalCiphertext ciphertext = 3;

--- a/src/main/proto/com/sunya/electionguard/protogen/plaintext_ballot.proto
+++ b/src/main/proto/com/sunya/electionguard/protogen/plaintext_ballot.proto
@@ -12,11 +12,13 @@ message PlaintextBallot {
 
 message PlaintextBallotContest {
   string contest_id = 1; // matches the ContestDescription.object_id
+  int32 sequence_order = 4;
   repeated PlaintextBallotSelection ballot_selections = 3;
 }
 
 message PlaintextBallotSelection {
   string selection_id = 1; // matches the SelectionDescription.object_id
+  int32 sequence_order = 5;
   uint32 vote = 2;
   bool is_placeholder_selection = 3;
   ExtendedData extended_data = 4;

--- a/src/main/proto/com/sunya/electionguard/protogen/plaintext_tally.proto
+++ b/src/main/proto/com/sunya/electionguard/protogen/plaintext_tally.proto
@@ -18,11 +18,13 @@ message PlaintextTallyContestMap {
 
 message PlaintextTallyContest {
   string object_id = 1;
+  int32 sequence_order = 3;
   map<string, PlaintextTallySelection> selections = 2;
 }
 
 message PlaintextTallySelection {
   string object_id = 1;
+  int32 sequence_order = 6;
   uint32 tally = 2;
   // g^tally or M in the spec.
   ElementModP value = 3;
@@ -32,6 +34,8 @@ message PlaintextTallySelection {
 
 message CiphertextDecryptionSelection {
   string object_id = 1;
+  int32 sequence_order = 7;
+
   // The Available Guardian that this share belongs to
   string guardian_id = 2;
 

--- a/src/test/java/com/sunya/electionguard/BallotFactory.java
+++ b/src/test/java/com/sunya/electionguard/BallotFactory.java
@@ -55,7 +55,7 @@ public class BallotFactory {
       }
     }
 
-    return new PlaintextBallot.Contest(description.object_id, selections);
+    return new PlaintextBallot.Contest(description.object_id(), description.sequence_order(), selections);
   }
 
   /** Get a single Fake Ballot object that is manually constructed with default values . */
@@ -79,6 +79,7 @@ public class BallotFactory {
   static PlaintextBallot.Selection get_selection_well_formed() {
     PlaintextBallot.ExtendedData extra_data = new PlaintextBallot.ExtendedData("random", 33);
     return new PlaintextBallot.Selection("selection-{draw(uuids)}",
+                42,
                 TestUtils.randomBool() ? 1 : 0,
                 false,
                 TestUtils.randomBool() ? extra_data : null);
@@ -87,6 +88,7 @@ public class BallotFactory {
   static PlaintextBallot.Selection get_selection_poorly_formed() {
     PlaintextBallot.ExtendedData extra_data = new PlaintextBallot.ExtendedData("random", 33);
     return new PlaintextBallot.Selection("selection-{draw(uuids)}",
+            43,
             TestUtils.randomBool() ? 2 : 3,
             TestUtils.randomBool(),
             TestUtils.randomBool() ? extra_data : null);

--- a/src/test/java/com/sunya/electionguard/ElectionTestHelper.java
+++ b/src/test/java/com/sunya/electionguard/ElectionTestHelper.java
@@ -499,7 +499,7 @@ public class ElectionTestHelper {
       no_votes.stream().map(d -> Encrypt.selection_from(d, false, false))
               .forEach(voted_selections::add);
 
-      voted_contests.add(new PlaintextBallot.Contest(contest.object_id, voted_selections));
+      voted_contests.add(new PlaintextBallot.Contest(contest.object_id(), contest.sequence_order(), voted_selections));
     }
 
     return new PlaintextBallot(randomString("PlaintextBallot"), ballot_style.object_id, voted_contests);

--- a/src/test/java/com/sunya/electionguard/TestDecryptWithSecretsProperties.java
+++ b/src/test/java/com/sunya/electionguard/TestDecryptWithSecretsProperties.java
@@ -66,7 +66,7 @@ public class TestDecryptWithSecretsProperties extends TestProperties {
     ElGamal.Ciphertext malformed_message = new ElGamal.Ciphertext(mult_p(subject.ciphertext().pad, TWO_MOD_P),
             subject.ciphertext().data);
     CiphertextBallot.Selection malformed_encryption = new CiphertextBallot.Selection(
-            subject.object_id, TWO_MOD_Q, malformed_message,
+            subject.object_id(), subject.sequence_order(), TWO_MOD_Q, malformed_message,
             subject.crypto_hash, subject.is_placeholder_selection, subject.nonce,
             subject.proof, subject.extended_data);
 
@@ -86,7 +86,7 @@ public class TestDecryptWithSecretsProperties extends TestProperties {
             proof.proof_one_response
     );
     CiphertextBallot.Selection malformed_proof = new CiphertextBallot.Selection(
-            subject.object_id, TWO_MOD_Q, malformed_message,
+            subject.object_id(), subject.sequence_order(), TWO_MOD_Q, malformed_message,
             subject.crypto_hash, subject.is_placeholder_selection, subject.nonce,
             Optional.of(malformed_disjunctive), subject.extended_data);
 
@@ -132,7 +132,7 @@ public class TestDecryptWithSecretsProperties extends TestProperties {
 
     // Tamper with the nonce by setting it to an arbitrary value
     CiphertextBallot.Selection bad_subject = new CiphertextBallot.Selection(
-            subject.object_id, subject.description_hash, subject.ciphertext(),
+            subject.object_id(), subject.sequence_order(), subject.description_hash, subject.ciphertext(),
             subject.crypto_hash, subject.is_placeholder_selection, Optional.of(nonce_seed),
             subject.proof, subject.extended_data);
 
@@ -279,7 +279,7 @@ public class TestDecryptWithSecretsProperties extends TestProperties {
 
     // tamper with the nonce
     CiphertextBallot.Contest bad_subject = new CiphertextBallot.Contest(
-            subject.object_id, subject.contest_hash,
+            subject.object_id(), subject.sequence_order(), subject.contest_hash,
             subject.ballot_selections, subject.crypto_hash,
             new ElGamal.Ciphertext(TWO_MOD_P, TWO_MOD_P),
             Optional.of(int_to_q_unchecked(BigInteger.ONE)), subject.proof);
@@ -305,7 +305,7 @@ public class TestDecryptWithSecretsProperties extends TestProperties {
     // Tamper with the encryption
     CiphertextBallot.Selection org = subject.ballot_selections.get(0);
     CiphertextBallot.Selection bad_selection = new CiphertextBallot.Selection(
-            org.object_id, org.description_hash, new ElGamal.Ciphertext(TWO_MOD_P, TWO_MOD_P),
+            org.object_id(), org.sequence_order(), org.description_hash, new ElGamal.Ciphertext(TWO_MOD_P, TWO_MOD_P),
             org.crypto_hash, org.is_placeholder_selection, org.nonce,
             org.proof, org.extended_data);
 
@@ -313,7 +313,7 @@ public class TestDecryptWithSecretsProperties extends TestProperties {
     bad_selections.set(0, bad_selection);
 
     CiphertextBallot.Contest bad_contest = new CiphertextBallot.Contest(
-            subject.object_id, subject.contest_hash,
+            subject.object_id(), subject.sequence_order(), subject.contest_hash,
             bad_selections, subject.crypto_hash, new ElGamal.Ciphertext(TWO_MOD_P, TWO_MOD_P),
             Optional.of(int_to_q_unchecked(BigInteger.ONE)), subject.proof);
 

--- a/src/test/java/com/sunya/electionguard/TestDecryption.java
+++ b/src/test/java/com/sunya/electionguard/TestDecryption.java
@@ -287,7 +287,7 @@ public class TestDecryption extends TestProperties {
     System.out.printf("%nRECONSTRUCTED SHARE%s%n", reconstructed_share);
 
     DecryptionShare.CiphertextDecryptionSelection share_2 = DecryptionShare.create_ciphertext_decryption_selection(
-            first_selection.object_id,
+            first_selection.object_id(),
             this.guardians.get(2).object_id,
             reconstructed_share,
             Optional.empty(),

--- a/src/test/java/com/sunya/electionguard/TestEncryptProperties.java
+++ b/src/test/java/com/sunya/electionguard/TestEncryptProperties.java
@@ -62,14 +62,14 @@ public class TestEncryptProperties extends TestProperties {
     // tamper with the description_hash
     // CiphertextBallotSelection malformed_description_hash = result.toBuilder().setDescriptionHash(TWO_MOD_Q).build();
     CiphertextBallot.Selection malformed_description_hash = new CiphertextBallot.Selection(
-            result.object_id, TWO_MOD_Q, result.ciphertext(),
+            result.object_id(), result.sequence_order(), TWO_MOD_Q, result.ciphertext(),
             result.crypto_hash, result.is_placeholder_selection, result.nonce,
             result.proof, result.extended_data);
 
     // remove the proof
     // CiphertextBallotSelection missing_proof = result.toBuilder().clearProof().build();
     CiphertextBallot.Selection missing_proof = new CiphertextBallot.Selection(
-            result.object_id, result.description_hash, result.ciphertext(),
+            result.object_id(), result.sequence_order(), result.description_hash, result.ciphertext(),
             result.crypto_hash, result.is_placeholder_selection, result.nonce,
             Optional.empty(), result.extended_data);
 
@@ -106,7 +106,7 @@ public class TestEncryptProperties extends TestProperties {
     // tamper with the encryption
     Ciphertext malformed_message = new Ciphertext(mult_p(result.ciphertext().pad, TWO_MOD_P), result.ciphertext().data);
     CiphertextBallot.Selection malformed_encryption = new CiphertextBallot.Selection(
-            result.object_id, TWO_MOD_Q, malformed_message,
+            result.object_id(), result.sequence_order(), TWO_MOD_Q, malformed_message,
             result.crypto_hash, result.is_placeholder_selection, result.nonce,
             result.proof, result.extended_data);
 
@@ -125,7 +125,7 @@ public class TestEncryptProperties extends TestProperties {
             proof.proof_one_response
     );
     CiphertextBallot.Selection malformed_proof = new CiphertextBallot.Selection(
-            result.object_id, TWO_MOD_Q, malformed_message,
+            result.object_id(), result.sequence_order(), TWO_MOD_Q, malformed_message,
             result.crypto_hash, result.is_placeholder_selection, result.nonce,
             Optional.of(malformed_disjunctive), result.extended_data);
 
@@ -210,7 +210,7 @@ public class TestEncryptProperties extends TestProperties {
             altered_a, proof.data, proof.challenge, proof.response, proof.constant);
 
     CiphertextBallot.Contest malformed_proof = new CiphertextBallot.Contest(
-            result.object_id, result.contest_hash,
+            result.object_id(), result.sequence_order(), result.contest_hash,
             result.ballot_selections, result.crypto_hash,
             new ElGamal.Ciphertext(TWO_MOD_P, TWO_MOD_P),
             result.nonce,
@@ -219,7 +219,7 @@ public class TestEncryptProperties extends TestProperties {
 
     // remove the proof
     CiphertextBallot.Contest missing_proof = new CiphertextBallot.Contest(
-            result.object_id, result.contest_hash,
+            result.object_id(), result.sequence_order(), result.contest_hash,
             result.ballot_selections, result.crypto_hash,
             new ElGamal.Ciphertext(TWO_MOD_P, TWO_MOD_P),
             result.nonce, Optional.empty());

--- a/src/test/java/com/sunya/electionguard/decrypting/TestDecryptingTrustee.java
+++ b/src/test/java/com/sunya/electionguard/decrypting/TestDecryptingTrustee.java
@@ -20,7 +20,7 @@ public class TestDecryptingTrustee {
   @Example
   public void testKeyCeremonyTrusteeGeneration() {
     assertThat(trustee1.id()).isEqualTo(GUARDIAN_ID + 1);
-    assertThat(trustee1.xCoordinate()).isEqualTo(1);
+    assertThat(trustee1.xCoordinate()).isEqualTo(1); // TODO FAILING
     assertThat(trustee1.electionPublicKey()).isNotNull();
 
     assertThat(trustee1.guardianCommittments.size()).isEqualTo(NGUARDIANS);

--- a/src/test/java/com/sunya/electionguard/input/BallotInputBuilder.java
+++ b/src/test/java/com/sunya/electionguard/input/BallotInputBuilder.java
@@ -28,6 +28,7 @@ public class BallotInputBuilder {
 
   public class ContestBuilder {
     private String id;
+    private int seq = 1;
     private ArrayList<SelectionBuilder> selections = new ArrayList<>();
 
     ContestBuilder(String id) {
@@ -45,7 +46,7 @@ public class BallotInputBuilder {
     }
 
     PlaintextBallot.Contest build() {
-      return new PlaintextBallot.Contest(id, selections.stream().map(SelectionBuilder::build).collect(Collectors.toList()));
+      return new PlaintextBallot.Contest(id, seq++, selections.stream().map(SelectionBuilder::build).collect(Collectors.toList()));
     }
 
     public class SelectionBuilder {
@@ -58,7 +59,7 @@ public class BallotInputBuilder {
       }
 
       PlaintextBallot.Selection build() {
-        return new PlaintextBallot.Selection(id, vote, false, null);
+        return new PlaintextBallot.Selection(id, seq++, vote, false, null);
       }
     }
   }

--- a/src/test/java/com/sunya/electionguard/input/CiphertextTallyInputBuilder.java
+++ b/src/test/java/com/sunya/electionguard/input/CiphertextTallyInputBuilder.java
@@ -35,6 +35,7 @@ public class CiphertextTallyInputBuilder {
 
   public class ContestBuilder {
     private String id;
+    private int seq = 1;
     private Group.ElementModQ hash;
     private ArrayList<SelectionBuilder> selections = new ArrayList<>();
 
@@ -54,11 +55,11 @@ public class CiphertextTallyInputBuilder {
     }
 
     CiphertextTally.Contest build() {
-      return new CiphertextTally.Contest(id, hash, selections.stream().collect(Collectors.toMap(s -> s.id, s -> s.build())));
+      return new CiphertextTally.Contest(id, seq++, hash, selections.stream().collect(Collectors.toMap(s -> s.id, s -> s.build())));
     }
 
     CiphertextTally.Contest buildBad() {
-      return new CiphertextTally.Contest(id, hash, selections.stream().collect(Collectors.toMap(s -> s.id + "bad", s -> s.build())));
+      return new CiphertextTally.Contest(id, seq++, hash, selections.stream().collect(Collectors.toMap(s -> s.id + "bad", s -> s.build())));
     }
 
     public class SelectionBuilder {
@@ -73,7 +74,7 @@ public class CiphertextTallyInputBuilder {
       }
 
       CiphertextTally.Selection build() {
-        return new CiphertextTally.Selection(id, hash, ciphertext);
+        return new CiphertextTally.Selection(id, seq++, hash, ciphertext);
       }
     }
   }

--- a/src/test/java/com/sunya/electionguard/input/PlaintextTallyInputBuilder.java
+++ b/src/test/java/com/sunya/electionguard/input/PlaintextTallyInputBuilder.java
@@ -72,6 +72,7 @@ public class PlaintextTallyInputBuilder {
 
     public class SelectionBuilder {
       private String id;
+      private int seq = 1;
       // LOOK no hash private Group.ElementModQ hash;
       private ElGamal.Ciphertext message;
       List<DecryptionShare.CiphertextDecryptionSelection> shares = new ArrayList<>();
@@ -115,7 +116,7 @@ public class PlaintextTallyInputBuilder {
 
       PlaintextTally.Selection build() {
         Group.ElementModP tally = Group.int_to_p_unchecked(BigInteger.valueOf(1));
-        return PlaintextTally.Selection.create(id, 1, Group.g_pow_p(tally), message, shares);
+        return PlaintextTally.Selection.create(id, seq++, 1, Group.g_pow_p(tally), message, shares);
       }
     }
   }

--- a/src/test/java/com/sunya/electionguard/publish/TestJsonRoundtrip.java
+++ b/src/test/java/com/sunya/electionguard/publish/TestJsonRoundtrip.java
@@ -128,6 +128,7 @@ public class TestJsonRoundtrip {
 
     CiphertextBallot.Contest contest = new CiphertextBallot.Contest(
             "testContestRoundtrip",
+            42,
             Group.ONE_MOD_Q,
             ImmutableList.of(),
             Group.ONE_MOD_Q,

--- a/src/test/java/com/sunya/electionguard/verifier/TestAttackTallyDecryptionVerifyier.java
+++ b/src/test/java/com/sunya/electionguard/verifier/TestAttackTallyDecryptionVerifyier.java
@@ -142,7 +142,7 @@ public class TestAttackTallyDecryptionVerifyier {
 
   private PlaintextTally.Selection messTally(PlaintextTally.Selection org) {
     System.out.printf("---messTally with %s%n", org.object_id());
-    return PlaintextTally.Selection.create(org.object_id(), org.tally() + 1, org.value(), org.message(), org.shares());
+    return PlaintextTally.Selection.create(org.object_id(), org.sequence_order(), org.tally() + 1, org.value(), org.message(), org.shares());
   }
 
   private PlaintextTally.Selection messTallyAndValue(PlaintextTally.Selection org) {
@@ -150,7 +150,7 @@ public class TestAttackTallyDecryptionVerifyier {
     int tally = org.tally() + 1;
     Group.ElementModP t = Group.int_to_p_unchecked(BigInteger.valueOf(tally));
     Group.ElementModP value = Group.g_pow_p(t);
-    return PlaintextTally.Selection.create(org.object_id(), tally, value, org.message(), org.shares());
+    return PlaintextTally.Selection.create(org.object_id(), org.sequence_order(), tally, value, org.message(), org.shares());
   }
 
   // Try to cheat by increasing the tally by one. Jigger the CiphertextDecryptionSelection to pass spec #11
@@ -190,7 +190,7 @@ public class TestAttackTallyDecryptionVerifyier {
     }
 
     // Group.ElementModP productMi = Group.mult_p(partialDecryptions);
-    return PlaintextTally.Selection.create(org.object_id(), tally, M, org.message(), shares);
+    return PlaintextTally.Selection.create(org.object_id(), org.sequence_order(), tally, M, org.message(), shares);
   }
 
   boolean publish(String inputDir, String publishDir, ElectionRecord electionRecord, PlaintextTally decryptedTally) throws IOException {


### PR DESCRIPTION
sequence_order is added to a whole bunch of classes.
Sort the contests and selections before doing a hash, for reproducible hashes.
Add OrderedObjectBaseIF. Not really needed, but following the python design.
Start to replace class ElectionObjectBase with interface ElectionObjectBaseIF.