### PR TITLE
Port "Expanded Submitted Ballot from Compact includes nonces" #489/491

### DIFF
--- a/src/main/java/com/sunya/electionguard/CompactSubmittedBallot.java
+++ b/src/main/java/com/sunya/electionguard/CompactSubmittedBallot.java
@@ -63,19 +63,14 @@ public class CompactSubmittedBallot {
             Encrypt.encrypt_ballot_contests(
                     plaintext_ballot, internal_manifest, context, nonce_seed).orElseThrow();
 
-    ElementModQ crypto_hash = CiphertextBallot.create_ballot_hash(
-            plaintext_ballot.object_id, internal_manifest.manifest.crypto_hash, contests);
-
-    return new SubmittedBallot(
+    return SubmittedBallot.create(
             plaintext_ballot.object_id,
             plaintext_ballot.style_id,
             internal_manifest.manifest.crypto_hash,
-            compact_ballot.code_seed,
+            Optional.of(compact_ballot.code_seed),
             contests,
             compact_ballot.code,
-            compact_ballot.timestamp,
-            crypto_hash,
-            Optional.of(compact_ballot.ballot_nonce),
+            Optional.of(compact_ballot.timestamp),
             compact_ballot.ballot_box_state);
   }
 

--- a/src/main/java/com/sunya/electionguard/SubmittedBallot.java
+++ b/src/main/java/com/sunya/electionguard/SubmittedBallot.java
@@ -19,6 +19,12 @@ import java.util.stream.Collectors;
 public class SubmittedBallot extends CiphertextBallot {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
+  // python: from_ciphertext_ballot
+  public static SubmittedBallot createFromCiphertextBallot(CiphertextBallot ballot, BallotBox.State state) {
+    return create(ballot.object_id, ballot.style_id, ballot.manifest_hash, Optional.of(ballot.code_seed),
+            ballot.contests, ballot.code, Optional.of(ballot.timestamp), state);
+  }
+
   /**
    * Makes a `SubmittedBallot`, ensuring that no nonces are part of the contests.
    * python: make_ciphertext_submitted_ballot()
@@ -70,7 +76,6 @@ public class SubmittedBallot extends CiphertextBallot {
             ballot_code,
             timestamp,
             contest_hash,
-            Optional.empty(),
             state);
   }
 
@@ -78,12 +83,7 @@ public class SubmittedBallot extends CiphertextBallot {
   /** The accepted state: CAST or SPOILED. */
   public final BallotBox.State state;
 
-  public SubmittedBallot(CiphertextBallot ballot, BallotBox.State state) {
-    super(ballot.object_id, ballot.style_id, ballot.manifest_hash, ballot.code_seed, ballot.contests,
-            ballot.code, ballot.timestamp, ballot.crypto_hash, ballot.nonce);
-    this.state = Preconditions.checkNotNull(state);
-  }
-
+  // public to allow proto serialization; use SubmittedBallot.create()
   public SubmittedBallot(String object_id,
                          String style_id,
                          Group.ElementModQ manifest_hash,
@@ -92,9 +92,8 @@ public class SubmittedBallot extends CiphertextBallot {
                          Group.ElementModQ code,
                          long timestamp,
                          Group.ElementModQ crypto_hash,
-                         Optional<Group.ElementModQ> nonce,
                          BallotBox.State state) {
-    super(object_id, style_id, manifest_hash, code_seed, contests, code, timestamp, crypto_hash, nonce);
+    super(object_id, style_id, manifest_hash, code_seed, contests, code, timestamp, crypto_hash, Optional.empty());
     this.state = state;
   }
 

--- a/src/main/java/com/sunya/electionguard/proto/CiphertextBallotFromProto.java
+++ b/src/main/java/com/sunya/electionguard/proto/CiphertextBallotFromProto.java
@@ -19,7 +19,7 @@ import com.sunya.electionguard.protogen.CiphertextBallotProto;
 public class CiphertextBallotFromProto {
 
   public static SubmittedBallot translateFromProto(CiphertextBallotProto.SubmittedBallot ballot) {
-    return new SubmittedBallot(
+    return SubmittedBallot.createFromCiphertextBallot(
             convertCiphertextBallot(ballot.getCiphertextBallot()),
             convertBallotBoxState(ballot.getState()));
   }

--- a/src/main/java/com/sunya/electionguard/publish/SubmittedBallotPojo.java
+++ b/src/main/java/com/sunya/electionguard/publish/SubmittedBallotPojo.java
@@ -105,7 +105,6 @@ public class SubmittedBallotPojo {
             pojo.code,
             pojo.timestamp,
             pojo.crypto_hash,
-            Optional.empty(), // Optional.ofNullable(pojo.nonce),
             pojo.state);
   }
 

--- a/src/test/java/com/sunya/electionguard/TestCompactBallot.java
+++ b/src/test/java/com/sunya/electionguard/TestCompactBallot.java
@@ -28,9 +28,7 @@ public class TestCompactBallot {
             Optional.empty(), true).orElseThrow();
     this.ballot_nonce = ciphertext_ballot.nonce.orElseThrow();
 
-    this.submitted_ballot = new SubmittedBallot(
-            ciphertext_ballot,
-            BallotBox.State.CAST);
+    this.submitted_ballot = SubmittedBallot.createFromCiphertextBallot(ciphertext_ballot, BallotBox.State.CAST);
   }
 
   @Example
@@ -53,11 +51,12 @@ public class TestCompactBallot {
     assertThat(compact_ballot).isNotNull();
     assertThat(this.submitted_ballot.object_id).isEqualTo(compact_ballot.compact_plaintext_ballot.object_id);
 
-    SubmittedBallot roundtrip = CompactSubmittedBallot.expand_compact_submitted_ballot(
+    SubmittedBallot expanded_ballot = CompactSubmittedBallot.expand_compact_submitted_ballot(
             compact_ballot, this.internal_manifest, this.context);
 
-    assertThat(roundtrip).isNotNull();
-    assertThat(roundtrip).isEqualTo(this.submitted_ballot);
+    assertThat(expanded_ballot).isNotNull();
+    assertThat(expanded_ballot.crypto_hash).isEqualTo(this.submitted_ballot.crypto_hash);
+    assertThat(expanded_ballot).isEqualTo(this.submitted_ballot);
   }
 
 

--- a/src/test/java/com/sunya/electionguard/publish/TestJsonRoundtrip.java
+++ b/src/test/java/com/sunya/electionguard/publish/TestJsonRoundtrip.java
@@ -145,7 +145,6 @@ public class TestJsonRoundtrip {
             Group.ONE_MOD_Q,
             1234L,
             Group.ONE_MOD_Q,
-            Optional.empty(), // LOOK we took out the nonce in SubmittedBallotPojo, since we cant read None
             BallotBox.State.CAST);
 
     // write json


### PR DESCRIPTION
CompactSubmittedBallot.expand_compact_submitted_ballot calls SubmittedBallot.create() instead of new SubmittedBallot()
refactor SubmittedBallot to be sure nonces are always null